### PR TITLE
refactor: Litho comments blockage generalization

### DIFF
--- a/app/src/main/java/app/revanced/integrations/adremover/LithoAdRemoval.java
+++ b/app/src/main/java/app/revanced/integrations/adremover/LithoAdRemoval.java
@@ -61,8 +61,7 @@ public class LithoAdRemoval {
             ) return true;
 
             if (SettingsEnum.ADREMOVER_COMMENTS_REMOVAL_BOOLEAN.getBoolean()) {
-                blockList.add("comments_composite_entry_point");
-                blockList.add("comments_entry_point_message");
+                blockList.add("comments_");
             }
             if (SettingsEnum.ADREMOVER_COMMUNITY_GUIDELINES_BOOLEAN.getBoolean()) {
                 blockList.add("community_guidelines");

--- a/app/src/main/java/app/revanced/integrations/adremover/LithoAdRemoval.java
+++ b/app/src/main/java/app/revanced/integrations/adremover/LithoAdRemoval.java
@@ -62,6 +62,7 @@ public class LithoAdRemoval {
 
             if (SettingsEnum.ADREMOVER_COMMENTS_REMOVAL_BOOLEAN.getBoolean()) {
                 blockList.add("comments_composite_entry_point");
+                blockList.add("comments_entry_point_message");
             }
             if (SettingsEnum.ADREMOVER_COMMUNITY_GUIDELINES_BOOLEAN.getBoolean()) {
                 blockList.add("community_guidelines");


### PR DESCRIPTION
This addition extends the litho comment blockage on those videos, where a box is shown to warns you that comments are turned off.

It's just a consistency patch, to ensure that anything related to comments remains hidden, when the dedicated toggle on settings page is enabled.