### PR TITLE
feat: block `channel-guidelines`. Fixes #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@
 - Usage on Linux: ```adb logcat | grep --line-buffered "ReVanced" > log.txt```
   
 This will write the log to a file called log.txt which you can view then.
+ 

--- a/app/src/main/java/app/revanced/integrations/patches/GeneralBytecodeAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralBytecodeAdsPatch.java
@@ -104,6 +104,9 @@ public class GeneralBytecodeAdsPatch {
             if (SettingsEnum.ADREMOVER_HIDE_LATEST_POSTS.getBoolean()) {
                 blockList.add("post_shelf");
             }
+            if (SettingsEnum.ADREMOVER_HIDE_CHANNEL_GUIDELINES.getBoolean()) {
+                blockList.add("channel_guidelines_entry_banner");
+            }
 
             if (containsAny(value,
                     "home_video_with_context",

--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -45,6 +45,7 @@ public enum SettingsEnum {
     ADREMOVER_SUGGESTED_FOR_YOU_REMOVAL("revanced_adremover_suggested", true, ReturnType.BOOLEAN),
     ADREMOVER_HIDE_SUGGESTIONS("revanced_adremover_hide_suggestions", true, ReturnType.BOOLEAN),
     ADREMOVER_HIDE_LATEST_POSTS("revanced_adremover_hide_latest_posts", true, ReturnType.BOOLEAN),
+    ADREMOVER_HIDE_CHANNEL_GUIDELINES("revanced_adremover_hide_channel_guidelines", true, ReturnType.BOOLEAN),
 
     //Layout settings
     REEL_BUTTON_SHOWN("revanced_reel_button_enabled", false, ReturnType.BOOLEAN),


### PR DESCRIPTION
See tracking issue
- https://github.com/revanced/revanced-integrations/issues/84