### PR TITLE
fix: simplify `old-quality` integration

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/OldQualityLayoutPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/OldQualityLayoutPatch.java
@@ -1,52 +1,21 @@
 package app.revanced.integrations.patches;
 
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
-import android.util.Log;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.Window;
+import android.os.Handler;
+import android.os.Looper;
 import android.widget.ListView;
-import android.widget.RelativeLayout;
-
-import java.util.Arrays;
 
 import app.revanced.integrations.settings.SettingsEnum;
 import app.revanced.integrations.utils.LogHelper;
 
 public class OldQualityLayoutPatch {
-    public static Window window;
-    private static boolean hideWindow = true;
-    
     public static void showOldQualityMenu(ListView listView)
     {
-        if (!SettingsEnum.OLD_STYLE_QUALITY_SETTINGS.getBoolean()) return;
+        listView.setVisibility(View.GONE);
 
-        hideWindow = true;
-
-        listView.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            @Override
-            public void onChildViewAdded(View parent, View child) {
-                LogHelper.debug(OldQualityLayoutPatch.class, "Added: " + child);
-
-                parent.setVisibility(View.GONE);
-                if (window != null && hideWindow) {
-                    window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-
-                    hideWindow = false;
+        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                @Override public void run() {
+                        listView.performItemClick(null, 4, 0);
                 }
-
-                final var indexOfAdvancedQualityMenuItem = 4;
-                if (listView.indexOfChild(child) != indexOfAdvancedQualityMenuItem) return;
-
-                LogHelper.debug(OldQualityLayoutPatch.class, "Found advanced menu: " + child);
-
-                final var qualityItemMenuPosition = 4;
-                listView.performItemClick(null, qualityItemMenuPosition, 0);
-            }
-
-            @Override
-            public void onChildViewRemoved(View parent, View child) {}
-        });
+        }, 1);
     }
 }

--- a/app/src/main/java/app/revanced/integrations/patches/OldQualityLayoutPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/OldQualityLayoutPatch.java
@@ -3,6 +3,7 @@ package app.revanced.integrations.patches;
 import android.os.Handler;
 import android.os.Looper;
 import android.widget.ListView;
+import android.view.View;
 
 import app.revanced.integrations.settings.SettingsEnum;
 

--- a/app/src/main/java/app/revanced/integrations/patches/OldQualityLayoutPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/OldQualityLayoutPatch.java
@@ -5,7 +5,6 @@ import android.os.Looper;
 import android.widget.ListView;
 
 import app.revanced.integrations.settings.SettingsEnum;
-import app.revanced.integrations.utils.LogHelper;
 
 public class OldQualityLayoutPatch {
     public static void showOldQualityMenu(ListView listView)


### PR DESCRIPTION
There's no other way to achieve a glitch-free `performItemClick`, neither with an onEndAnimation Listener (listView doesn't have any animation) for example, or other triggers. And we don't need a too much complex code.

Plus, despite not making the patch work in the absence of a delay (1ms is enough), runnable prevents FragmentManager crash issue in app.

This characteristic makes it also the safest way to apply this mod.