### PR TITLE
fix: logic in `VideoAdsPatch`

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/VideoAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/VideoAdsPatch.java
@@ -5,10 +5,10 @@ import app.revanced.integrations.whitelist.Whitelist;
 
 public class VideoAdsPatch {
 
-    //Used by app.revanced.patches.youtube.ad.general.video.patch.VideoAdsPatch
-    //depends on Whitelist Patch. Still needs to be written
+    // Used by app.revanced.patches.youtube.ad.general.video.patch.VideoAdsPatch
+    // depends on Whitelist patch (still needs to be written)
     public static boolean shouldShowAds() {
-        return SettingsEnum.VIDEO_ADS_SHOWN.getBoolean() && Whitelist.shouldShowAds();
+        return SettingsEnum.VIDEO_ADS_SHOWN.getBoolean() || Whitelist.shouldShowAds();
     }
 
 }


### PR DESCRIPTION
before: ads are shown only when video ads are enabled AND channel is whitelisted
(means without using the whitelist the ads toggle doesn't do anything, making it useless if you want to support all creators)

after: ads are shown when either video ads toggle is enabled OR channel is whitelisted

also format the comments