### PR TITLE
feat: `overlay-buttons` patch

### DIFF
--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -57,6 +57,9 @@ public enum SettingsEnum {
     //Misc. Settings
     //ToDo: Not used atm, Patch missing
     CAPTIONS_ENABLED("revanced_pref_captions", false, ReturnType.BOOLEAN),
+    PREFERRED_COPY_BUTTON("revanced_pref_copy_video_url_button", false, ReturnType.BOOLEAN),
+    PREFERRED_COPY_WITH_TIMESTAMP_BUTTON("revanced_pref_copy_video_url_timestamp_button", false, ReturnType.BOOLEAN),
+    PREFERRED_AUTO_REPEAT_BUTTON("revanced_pref_auto_repeat_button", false, ReturnType.BOOLEAN),
     PREFERRED_AUTO_REPEAT("revanced_pref_auto_repeat", true, ReturnType.BOOLEAN),
     USE_HDR_AUTO_BRIGHTNESS("revanced_pref_hdr_autobrightness", true, ReturnType.BOOLEAN),
     TAP_SEEKING_ENABLED("revanced_enable_tap_seeking", true, ReturnType.BOOLEAN),

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReVancedSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReVancedSettingsFragment.java
@@ -29,6 +29,8 @@ import app.revanced.integrations.utils.LogHelper;
 import app.revanced.integrations.utils.ReVancedUtils;
 import app.revanced.integrations.utils.SharedPrefHelper;
 import app.revanced.integrations.videoplayer.AutoRepeat;
+import app.revanced.integrations.videoplayer.Copy;
+import app.revanced.integrations.videoplayer.CopyWithTimeStamp;
 
 public class ReVancedSettingsFragment extends PreferenceFragment {
 
@@ -53,8 +55,14 @@ public class ReVancedSettingsFragment extends PreferenceFragment {
                 SwitchPreference switchPref = (SwitchPreference) pref;
                 setting.setValue(switchPref.isChecked());
 
-                if (setting == SettingsEnum.PREFERRED_AUTO_REPEAT) {
-                    AutoRepeat.changeSelected(setting.getBoolean(), true);
+                if (setting == SettingsEnum.PREFERRED_COPY_BUTTON) {
+                    Copy.refreshShouldBeShown();
+                } else if (setting == SettingsEnum.PREFERRED_COPY_WITH_TIMESTAMP_BUTTON) {
+                    CopyWithTimeStamp.refreshShouldBeShown();
+                } else if (setting == SettingsEnum.PREFERRED_AUTO_REPEAT_BUTTON) {
+                    ReVancedSettingsFragment.this.AutoRepeatLinks();
+                } else if (setting == SettingsEnum.PREFERRED_AUTO_REPEAT) {
+                    AutoRepeat.changeSelected(SettingsEnum.PREFERRED_AUTO_REPEAT.getBoolean(), true);
                 }
 
             } else if (pref instanceof EditTextPreference) {
@@ -130,7 +138,7 @@ public class ReVancedSettingsFragment extends PreferenceFragment {
             this.screens.add((PreferenceScreen) getPreferenceScreen().findPreference("buffer_screen"));
             this.screens.add((PreferenceScreen) getPreferenceScreen().findPreference("misc_screen"));
             this.screens.add((PreferenceScreen) getPreferenceScreen().findPreference("swipe_screen"));
-
+			AutoRepeatLinks();
 
             final ListPreference listPreference3 = (ListPreference) screens.get(1).findPreference("revanced_pref_video_speed");
             setSpeedListPreferenceData(listPreference3);
@@ -174,6 +182,21 @@ public class ReVancedSettingsFragment extends PreferenceFragment {
         }
 
         return pref;
+    }
+
+    public void AutoRepeatLinks() {
+        boolean z = SettingsEnum.PREFERRED_AUTO_REPEAT_BUTTON.getBoolean();
+        SwitchPreference switchPreference = (SwitchPreference) findPreferenceOnScreen("revanced_pref_auto_repeat");
+        if (switchPreference == null) {
+            return;
+        }
+        if (z) {
+            switchPreference.setEnabled(false);
+            AutoRepeat.isAutoRepeatBtnEnabled = true;
+            return;
+        }
+        switchPreference.setEnabled(true);
+        AutoRepeat.isAutoRepeatBtnEnabled = false;
     }
 
     private void setSpeedListPreferenceData(ListPreference listPreference) {

--- a/app/src/main/java/app/revanced/integrations/videoplayer/AutoRepeat.java
+++ b/app/src/main/java/app/revanced/integrations/videoplayer/AutoRepeat.java
@@ -1,6 +1,7 @@
 package app.revanced.integrations.videoplayer;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import android.view.View;
 import android.view.animation.Animation;
@@ -31,8 +32,6 @@ public class AutoRepeat {
     public static void initializeAutoRepeat(Object constraintLayout) {
         try {
             LogHelper.debug(AutoRepeat.class, "initializing auto repeat");
-            CopyWithTimeStamp.initializeCopyButtonWithTimeStamp(constraintLayout);
-            Copy.initializeCopyButton(constraintLayout);
             _constraintLayout = (ConstraintLayout) constraintLayout;
             isAutoRepeatBtnEnabled = shouldBeShown();
             ImageView imageView = _constraintLayout.findViewById(getIdentifier("autoreplay_button", "id"));
@@ -64,8 +63,6 @@ public class AutoRepeat {
     }
 
     public static void changeVisibility(boolean visible) {
-        CopyWithTimeStamp.changeVisibility(visible);
-        Copy.changeVisibility(visible);
         if (isShowing != visible) {
             isShowing = visible;
             ImageView iView = _autoRepeatBtn.get();
@@ -109,12 +106,16 @@ public class AutoRepeat {
             LogHelper.printException(AutoRepeat.class, "ChangeSelected - context is null!");
             return false;
         }
-        return SharedPrefHelper.getBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "pref_auto_repeat", false);
+        return SharedPrefHelper.getBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "revanced_pref_auto_repeat", false);
     }
 
     private static void setSelected(boolean selected) {
         Context context = ReVancedUtils.getContext();
-        SharedPrefHelper.saveBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "pref_auto_repeat", selected);
+        if (context == null) {
+            LogHelper.printException(AutoRepeat.class, "ChangeSelected - context is null!");
+            return;
+        }
+        SettingsEnum.PREFERRED_AUTO_REPEAT.saveValue(selected);
     }
 
     private static boolean shouldBeShown() {
@@ -123,7 +124,7 @@ public class AutoRepeat {
             LogHelper.printException(AutoRepeat.class, "ChangeSelected - context is null!");
             return false;
         }
-        return SharedPrefHelper.getBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "pref_auto_repeat_button", false);
+        return SharedPrefHelper.getBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "revanced_pref_auto_repeat_button", false);
     }
 
     private static int getIdentifier(String name, String defType) {

--- a/app/src/main/java/app/revanced/integrations/videoplayer/Copy.java
+++ b/app/src/main/java/app/revanced/integrations/videoplayer/Copy.java
@@ -82,16 +82,18 @@ public class Copy {
     }
 
     private static boolean shouldBeShown() {
-        Context appContext = ReVancedUtils.getContext();
-        if (appContext == null) {
+        Context context = ReVancedUtils.getContext();
+        if (context == null) {
             LogHelper.printException(Copy.class, "shouldBeShown - context is null!");
             return false;
         }
-        String string = SharedPrefHelper.getString(appContext, SharedPrefHelper.SharedPrefNames.YOUTUBE, "pref_copy_video_url_button_list", null);
+		/*
         if (string == null || string.isEmpty()) {
             return false;
         }
         return string.equalsIgnoreCase("PLAYER") || string.equalsIgnoreCase("BOTH");
+        */
+        return SharedPrefHelper.getBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "revanced_pref_copy_video_url_button", false);
     }
 
     private static int getIdentifier(String str, String str2) {

--- a/app/src/main/java/app/revanced/integrations/videoplayer/CopyWithTimeStamp.java
+++ b/app/src/main/java/app/revanced/integrations/videoplayer/CopyWithTimeStamp.java
@@ -85,17 +85,18 @@ public class CopyWithTimeStamp {
     }
 
     private static boolean shouldBeShown() {
-        Context appContext = ReVancedUtils.getContext();
-        if (appContext == null) {
+        Context context = ReVancedUtils.getContext();
+        if (context == null) {
             LogHelper.printException(CopyWithTimeStamp.class, "shouldBeShown - context is null!");
             return false;
         }
-
-        String string = SharedPrefHelper.getString(appContext, SharedPrefHelper.SharedPrefNames.YOUTUBE, "pref_copy_video_url_timestamp_button_list", null);
+        /*
         if (string == null || string.isEmpty()) {
             return false;
         }
         return string.equalsIgnoreCase("PLAYER") || string.equalsIgnoreCase("BOTH");
+        */
+        return SharedPrefHelper.getBoolean(context, SharedPrefHelper.SharedPrefNames.YOUTUBE, "revanced_pref_copy_video_url_timestamp_button", false);
     }
 
     private static int getIdentifier(String str, String str2) {


### PR DESCRIPTION
I didn't know what to name this, so I named it 'overlay-buttons'
This is a patch for a button inside the player that was in Vanced. (Copy, Copy With Timestamp, Autorepeat)

Screenshot
https://imgur.com/a/m3HLV2G

Since the button container at the bottom of the player has been moved to litho, instead of using the existing array settings (NONE, PLAYER, BUTTON_CONTAINER, BOTH), I simply implemented it as an ON/OFF switch (BOOLEAN).

needs to be merged together with [revanced-patches](https://github.com/revanced/revanced-patches/pull/353)