### PR TITLE
fix: add more block string to `LithoAd` filter

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/GeneralBytecodeAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralBytecodeAdsPatch.java
@@ -40,6 +40,7 @@ public class GeneralBytecodeAdsPatch {
                 blockList.add("shelf_header");
                 blockList.add("text_search_ad_with_description_first");
                 blockList.add("watch_metadata_app_promo");
+                blockList.add("video_display_full_layout");
 
                 bufferBlockList.add("ad_cpn");
             }


### PR DESCRIPTION
Add `video_display_full_layout` to value blockList of LithoAd filter. Possibly fix https://github.com/revanced/revanced-patches/issues/432