### PR TITLE
fix(sponsorblock): return details of 400 error

### DIFF
--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
@@ -101,6 +101,9 @@ public class SBRequester {
                 case 429:
                     SponsorBlockUtils.messageToToast = str("submit_failed_rate_limit");
                     break;
+                case 400:
+                    SponsorBlockUtils.messageToToast = str("submit_failed_invalid", connection.getErrorStream());
+                    break;
                 default:
                     SponsorBlockUtils.messageToToast = str("submit_failed_unknown_error", responseCode, connection.getResponseMessage());
                     break;


### PR DESCRIPTION
Users are coming into the SponsorBlock discord presenting error 400, which is a generic catch-all for inputs that are bad or impossible. This is usually a bad userID but eating the error makes troubleshooting extremely difficult when it's not.

Possible causes of 400
- userID
- videoID
- no segments
- invalid segment times
- descriptions on non-chapters
- chapters that exceed limit
- lack of permissions