### PR TITLE
fix: revert removing getAppContext()

### DIFF
--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReVancedSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReVancedSettingsFragment.java
@@ -18,6 +18,7 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 
+import com.google.android.apps.youtube.app.YouTubeTikTokRoot_Application;
 import com.google.android.apps.youtube.app.application.Shell_HomeActivity;
 
 import java.util.List;
@@ -173,7 +174,7 @@ public class ReVancedSettingsFragment extends PreferenceFragment {
     */
 
     private String getPackageName() {
-        Context context = ReVancedUtils.getContext();
+        Context context = YouTubeTikTokRoot_Application.getAppContext();
         if (context == null) {
             LogHelper.printException(ReVancedSettingsFragment.class, "Context is null, returning com.google.android.youtube!");
             return "com.google.android.youtube";

--- a/app/src/main/java/app/revanced/integrations/utils/ReVancedUtils.java
+++ b/app/src/main/java/app/revanced/integrations/utils/ReVancedUtils.java
@@ -5,6 +5,8 @@ import android.content.res.Resources;
 import android.os.Handler;
 import android.os.Looper;
 
+import com.google.android.apps.youtube.app.YouTubeTikTokRoot_Application;
+
 import app.revanced.integrations.sponsorblock.player.PlayerType;
 
 public class ReVancedUtils {
@@ -15,6 +17,13 @@ public class ReVancedUtils {
     //Used by Integrations patch
     public static Context context;
     //Used by Integrations patch
+    public static Context getAppContext() {
+        if (context != null) {
+            return context;
+        }
+        LogHelper.printException(ReVancedUtils.class, "Context is null!");
+        return null;
+    }
 
     public static void setNewVideo(boolean started) {
         LogHelper.debug(ReVancedUtils.class, "New video started: " + started);
@@ -52,6 +61,7 @@ public class ReVancedUtils {
     }
 
     public static Context getContext() {
+        Context context = YouTubeTikTokRoot_Application.getAppContext();
         if (context != null) {
             return context;
         } else {

--- a/app/src/main/java/com/google/android/apps/youtube/app/YouTubeTikTokRoot_Application.java
+++ b/app/src/main/java/com/google/android/apps/youtube/app/YouTubeTikTokRoot_Application.java
@@ -1,0 +1,10 @@
+package com.google.android.apps.youtube.app;
+
+import android.app.Application;
+import android.content.Context;
+
+public class YouTubeTikTokRoot_Application extends Application {
+    public static Context getAppContext() {
+        return null;
+    }
+}


### PR DESCRIPTION
Reverts revanced/revanced-integrations#180 because it was marked as a refactor and did not trigger CI. A separate PR should the  revert this PR with a fix.