### PR TITLE
fix(youtube/general-ads-patch): improved blocking furthermore

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/LithoFilterPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/LithoFilterPatch.java
@@ -213,7 +213,7 @@ class GeneralBytecodeAdsPatch extends Filter {
                 // could be required
                 //"full_width_square_image_layout",
                 "video_display_full_buttoned_layout",
-                "_ad",
+                "_ad_",
                 "ad_badge",
                 "ads_video_with_context",
                 "banner_text_icon",


### PR DESCRIPTION
To avoid eventually other unwanted blocks, it would be better to perform a more selective ads blocking, also because the isn't any template name that ends with ```_ad``` (instead there are 2 of that which contains ```_ad_```).