### PR TITLE
ReturnYouTubeDislike connection statistics. Show client toast messages on RYD connection errors.  High priority background threads.

### DIFF
--- a/app/src/main/java/app/revanced/integrations/requests/Requester.java
+++ b/app/src/main/java/app/revanced/integrations/requests/Requester.java
@@ -58,8 +58,9 @@ public class Requester {
      * Parse, and then do NOT disconnect the {@link HttpURLConnection}
      */
     public static String parseErrorJson(HttpURLConnection connection) throws IOException {
-        // TODO: make this also disconnect, and rename method to #parseErrorJsonAndDisconnect
-        return parseJson(connection.getErrorStream(), true);
+        String result = parseJson(connection.getErrorStream(), true);
+//        connection.disconnect(); // TODO: uncomment this line and rename method to #parseErrorJsonAndDisconnect
+        return result;
     }
 
     /**

--- a/app/src/main/java/app/revanced/integrations/requests/Requester.java
+++ b/app/src/main/java/app/revanced/integrations/requests/Requester.java
@@ -33,7 +33,7 @@ public class Requester {
     }
 
     /**
-     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect.
      *
      * <b>Should only be used if other requests to the server are unlikely in the near future</b>
      *
@@ -71,7 +71,7 @@ public class Requester {
     }
 
     /**
-     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect.
      *
      * <b>Should only be used if other requests to the server are unlikely in the near future</b>
      *
@@ -91,7 +91,7 @@ public class Requester {
     }
 
     /**
-     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect.
      *
      * <b>Should only be used if other requests to the server are unlikely in the near future</b>
      *
@@ -111,7 +111,7 @@ public class Requester {
     }
 
     /**
-     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect.
      *
      * <b>Should only be used if other requests to the server are unlikely in the near future</b>
      *

--- a/app/src/main/java/app/revanced/integrations/requests/Requester.java
+++ b/app/src/main/java/app/revanced/integrations/requests/Requester.java
@@ -40,14 +40,17 @@ public class Requester {
 
     /**
      * Parse, and then close the {@link InputStream}
+     *
+     * @param retainNewLineCharacters if newline (\n) characters should be retained in the parsed string.
+     *                                If false, then newlines are stripped from the InputStream
      */
-    public static String parseInputStreamAndClose(InputStream inputStream, boolean isError) throws IOException {
+    public static String parseInputStreamAndClose(InputStream inputStream, boolean retainNewLineCharacters) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
             StringBuilder jsonBuilder = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
                 jsonBuilder.append(line);
-                if (isError)
+                if (retainNewLineCharacters)
                     jsonBuilder.append("\n");
             }
             return jsonBuilder.toString();

--- a/app/src/main/java/app/revanced/integrations/requests/Requester.java
+++ b/app/src/main/java/app/revanced/integrations/requests/Requester.java
@@ -31,7 +31,7 @@ public class Requester {
      * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
      */
     public static String parseJson(HttpURLConnection connection, boolean disconnect) throws IOException {
-        String result = parseInputStreamAndClose(connection.getInputStream(), false);
+        String result = parseInputStreamAndClose(connection.getInputStream(), true);
         if (disconnect) {
             connection.disconnect();
         }
@@ -41,16 +41,15 @@ public class Requester {
     /**
      * Parse, and then close the {@link InputStream}
      *
-     * @param retainNewLineCharacters if newline (\n) characters should be retained in the parsed string.
-     *                                If false, then newlines are stripped from the InputStream
+     * @param stripNewLineCharacters if newline (\n) characters should be stripped from the InputStream
      */
-    public static String parseInputStreamAndClose(InputStream inputStream, boolean retainNewLineCharacters) throws IOException {
+    public static String parseInputStreamAndClose(InputStream inputStream, boolean stripNewLineCharacters) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
             StringBuilder jsonBuilder = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
                 jsonBuilder.append(line);
-                if (retainNewLineCharacters)
+                if (!stripNewLineCharacters)
                     jsonBuilder.append("\n");
             }
             return jsonBuilder.toString();
@@ -63,7 +62,7 @@ public class Requester {
      * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
      */
     public static String parseErrorJson(HttpURLConnection connection, boolean disconnect) throws IOException {
-        String result = parseInputStreamAndClose(connection.getErrorStream(), true);
+        String result = parseInputStreamAndClose(connection.getErrorStream(), false);
         if (disconnect) {
             connection.disconnect();
         }

--- a/app/src/main/java/app/revanced/integrations/requests/Requester.java
+++ b/app/src/main/java/app/revanced/integrations/requests/Requester.java
@@ -26,20 +26,27 @@ public class Requester {
     }
 
     /**
-     * Parse the {@link HttpURLConnection} and optionally disconnect.
-     *
-     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
+     * Parse the {@link HttpURLConnection}, and closes the underlying InputStream.
      */
-    public static String parseJson(HttpURLConnection connection, boolean disconnect) throws IOException {
-        String result = parseInputStreamAndClose(connection.getInputStream(), true);
-        if (disconnect) {
-            connection.disconnect();
-        }
+    public static String parseJson(HttpURLConnection connection) throws IOException {
+        return parseInputStreamAndClose(connection.getInputStream(), true);
+    }
+
+    /**
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     *
+     * <b>Should only be used if other requests to the server are unlikely in the near future</b>
+     *
+     * @see #parseJson(HttpURLConnection)
+     */
+    public static String parseJsonAndDisconnect(HttpURLConnection connection) throws IOException {
+        String result = parseJson(connection);
+        connection.disconnect();
         return result;
     }
 
     /**
-     * Parse, and then close the {@link InputStream}
+     * Parse the {@link HttpURLConnection}, and closes the underlying InputStream.
      *
      * @param stripNewLineCharacters if newline (\n) characters should be stripped from the InputStream
      */
@@ -57,34 +64,63 @@ public class Requester {
     }
 
     /**
-     * Parse the {@link HttpURLConnection} and optionally disconnect.
-     *
-     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
+     * Parse the {@link HttpURLConnection}, and closes the underlying InputStream.
      */
-    public static String parseErrorJson(HttpURLConnection connection, boolean disconnect) throws IOException {
-        String result = parseInputStreamAndClose(connection.getErrorStream(), false);
-        if (disconnect) {
-            connection.disconnect();
-        }
+    public static String parseErrorJson(HttpURLConnection connection) throws IOException {
+        return parseInputStreamAndClose(connection.getErrorStream(), false);
+    }
+
+    /**
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     *
+     * <b>Should only be used if other requests to the server are unlikely in the near future</b>
+     *
+     * @see #parseErrorJson(HttpURLConnection)
+     */
+    public static String parseErrorJsonAndDisconnect(HttpURLConnection connection) throws IOException {
+        String result = parseErrorJson(connection);
+        connection.disconnect();
         return result;
     }
 
     /**
-     * Parse the {@link HttpURLConnection} and optionally disconnect.
-     *
-     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
+     * Parse the {@link HttpURLConnection}, and closes the underlying InputStream.
      */
-    public static JSONObject getJSONObject(HttpURLConnection connection, boolean disconnect) throws JSONException, IOException {
-        return new JSONObject(parseJson(connection, disconnect));
+    public static JSONObject parseJSONObject(HttpURLConnection connection) throws JSONException, IOException {
+        return new JSONObject(parseJson(connection));
     }
 
     /**
-     * Parse the {@link HttpURLConnection} and optionally disconnect.
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
      *
-     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
+     * <b>Should only be used if other requests to the server are unlikely in the near future</b>
+     *
+     * @see #parseJSONObject(HttpURLConnection)
      */
-    public static JSONArray getJSONArray(HttpURLConnection connection, boolean disconnect) throws JSONException, IOException  {
-        return new JSONArray(parseJson(connection, disconnect));
+    public static JSONObject parseJSONObjectAndDisconnect(HttpURLConnection connection) throws JSONException, IOException {
+        JSONObject object = parseJSONObject(connection);
+        connection.disconnect();
+        return object;
+    }
+
+    /**
+     * Parse the {@link HttpURLConnection}, and closes the underlying InputStream.
+     */
+    public static JSONArray parseJSONArray(HttpURLConnection connection) throws JSONException, IOException  {
+        return new JSONArray(parseJson(connection));
+    }
+
+    /**
+     * Parse the {@link HttpURLConnection}, close the underlying InputStream, and disconnect the connect.
+     *
+     * <b>Should only be used if other requests to the server are unlikely in the near future</b>
+     *
+     * @see #parseJSONArray(HttpURLConnection)
+     */
+    public static JSONArray parseJSONArrayAndDisconnect(HttpURLConnection connection) throws JSONException, IOException  {
+        JSONArray array = parseJSONArray(connection);
+        connection.disconnect();
+        return array;
     }
 
 }

--- a/app/src/main/java/app/revanced/integrations/requests/Requester.java
+++ b/app/src/main/java/app/revanced/integrations/requests/Requester.java
@@ -26,22 +26,22 @@ public class Requester {
     }
 
     /**
-     * Parse, and then disconnect the {@link HttpURLConnection}
+     * Parse the {@link HttpURLConnection} and optionally disconnect.
      *
-     * TODO: rename this to #parseJsonAndDisconnect
+     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
      */
-    public static String parseJson(HttpURLConnection connection) throws IOException {
-        String result = parseJson(connection.getInputStream(), false);
-        connection.disconnect();
+    public static String parseJson(HttpURLConnection connection, boolean disconnect) throws IOException {
+        String result = parseInputStreamAndClose(connection.getInputStream(), false);
+        if (disconnect) {
+            connection.disconnect();
+        }
         return result;
     }
 
     /**
      * Parse, and then close the {@link InputStream}
-     *
-     * TODO: rename this to #parseJsonAndCloseStream
      */
-    public static String parseJson(InputStream inputStream, boolean isError) throws IOException {
+    public static String parseInputStreamAndClose(InputStream inputStream, boolean isError) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
             StringBuilder jsonBuilder = new StringBuilder();
             String line;
@@ -55,35 +55,34 @@ public class Requester {
     }
 
     /**
-     * Parse, and then do NOT disconnect the {@link HttpURLConnection}
+     * Parse the {@link HttpURLConnection} and optionally disconnect.
+     *
+     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
      */
-    public static String parseErrorJson(HttpURLConnection connection) throws IOException {
-        String result = parseJson(connection.getErrorStream(), true);
-//        connection.disconnect(); // TODO: uncomment this line and rename method to #parseErrorJsonAndDisconnect
+    public static String parseErrorJson(HttpURLConnection connection, boolean disconnect) throws IOException {
+        String result = parseInputStreamAndClose(connection.getErrorStream(), true);
+        if (disconnect) {
+            connection.disconnect();
+        }
         return result;
     }
 
     /**
-     * Parse, and then disconnect the {@link HttpURLConnection}
+     * Parse the {@link HttpURLConnection} and optionally disconnect.
      *
-     * TODO: rename this to #getJSONObjectAndDisconnect
+     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
      */
-    public static JSONObject getJSONObject(HttpURLConnection connection) throws JSONException, IOException {
-        return new JSONObject(parseJsonAndDisconnect(connection));
+    public static JSONObject getJSONObject(HttpURLConnection connection, boolean disconnect) throws JSONException, IOException {
+        return new JSONObject(parseJson(connection, disconnect));
     }
 
     /**
-     * Parse, and then disconnect the {@link HttpURLConnection}
+     * Parse the {@link HttpURLConnection} and optionally disconnect.
      *
-     * TODO: rename this to #getJSONArrayAndDisconnect
+     * @param disconnect should be true, <b>only if other requests to the server are unlikely in the near future</b>
      */
-    public static JSONArray getJSONArray(HttpURLConnection connection) throws JSONException, IOException  {
-        return new JSONArray(parseJsonAndDisconnect(connection));
+    public static JSONArray getJSONArray(HttpURLConnection connection, boolean disconnect) throws JSONException, IOException  {
+        return new JSONArray(parseJson(connection, disconnect));
     }
 
-    private static String parseJsonAndDisconnect(HttpURLConnection connection) throws IOException {
-        String json = parseJson(connection);
-        connection.disconnect();
-        return json;
-    }
 }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -317,13 +317,13 @@ public class ReturnYouTubeDislike {
             return;
         }
         final long timeUIWaitingTotal = System.currentTimeMillis() - timeUIWaitStarted;
-        LogHelper.printDebug(() -> "UI thread paused for: " + timeUIWaitingTotal + "ms waiting for vote fetch to complete");
+        LogHelper.printDebug(() -> "UI thread waited for: " + timeUIWaitingTotal + "ms for vote fetch to complete");
 
         totalTimeUIWaitedOnNetworkCalls += timeUIWaitingTotal;
         numberOfTimesUIWaitedOnNetworkCalls++;
         final long averageTimeForcedToWait = totalTimeUIWaitedOnNetworkCalls / numberOfTimesUIWaitedOnNetworkCalls;
         LogHelper.printDebug(() -> "UI thread forced to wait: " + numberOfTimesUIWaitedOnNetworkCalls + " times, "
-                + "total wait time of: " + totalTimeUIWaitedOnNetworkCalls + "ms, "
-                + "average wait time of: " + averageTimeForcedToWait + "ms") ;
+                + "total wait time: " + totalTimeUIWaitedOnNetworkCalls + "ms, "
+                + "average wait time: " + averageTimeForcedToWait + "ms") ;
     }
 }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -40,7 +40,7 @@ public class ReturnYouTubeDislike {
      */
     private static final ExecutorService voteSerialExecutor = Executors.newSingleThreadExecutor();
 
-    // Must be volatile, since non-main threads read this field.
+    // Must be volatile, since this is read/wright from different threads
     private static volatile boolean isEnabled = SettingsEnum.RYD_ENABLED.getBoolean();
 
     /**

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -40,7 +40,7 @@ public class ReturnYouTubeDislike {
      */
     private static final ExecutorService voteSerialExecutor = Executors.newSingleThreadExecutor();
 
-    // Must be volatile, since this is read/wright from different threads
+    // Must be volatile, since this is read/write from different threads
     private static volatile boolean isEnabled = SettingsEnum.RYD_ENABLED.getBoolean();
 
     /**

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -305,12 +305,12 @@ public class ReturnYouTubeDislike {
     /**
      * Number of times the UI was forced to wait on a network fetch to complete
      */
-    private static int numberOfTimesUIWaitedOnNetworkCall;
+    private static int numberOfTimesUIWaitedOnNetworkCalls;
 
     /**
      * Total time the UI waited, of all times it was forced to wait.
      */
-    private static long totalTimeUIWaited;
+    private static long totalTimeUIWaitedOnNetworkCalls;
 
     private static void recordTimeUISpentWaitingForNetworkCall(long timeUIWaitingStarted) {
         if (timeUIWaitingStarted == 0 || !SettingsEnum.DEBUG.getBoolean()) {
@@ -319,11 +319,11 @@ public class ReturnYouTubeDislike {
         final long timeUIWaitingTotal = System.currentTimeMillis() - timeUIWaitingStarted;
         LogHelper.printDebug(() -> "UI thread paused for: " + timeUIWaitingTotal + "ms waiting for vote fetch to complete");
 
-        totalTimeUIWaited += timeUIWaitingTotal;
-        numberOfTimesUIWaitedOnNetworkCall++;
-        final long averageTimeForcedToWait = totalTimeUIWaited / numberOfTimesUIWaitedOnNetworkCall;
-        LogHelper.printDebug(() -> "UI thread forced to wait: " + numberOfTimesUIWaitedOnNetworkCall + " times, "
-                + "total wait time of: " + totalTimeUIWaited + "ms, "
+        totalTimeUIWaitedOnNetworkCalls += timeUIWaitingTotal;
+        numberOfTimesUIWaitedOnNetworkCalls++;
+        final long averageTimeForcedToWait = totalTimeUIWaitedOnNetworkCalls / numberOfTimesUIWaitedOnNetworkCalls;
+        LogHelper.printDebug(() -> "UI thread forced to wait: " + numberOfTimesUIWaitedOnNetworkCalls + " times, "
+                + "total wait time of: " + totalTimeUIWaitedOnNetworkCalls + "ms, "
                 + "average wait time of: " + averageTimeForcedToWait + "ms") ;
     }
 }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -308,9 +308,9 @@ public class ReturnYouTubeDislike {
     private static int numberOfTimesUIWaitedOnNetworkCall;
 
     /**
-     * Average amount of time the UI waited, of all times it was forced to wait.
+     * Total time the UI waited, of all times it was forced to wait.
      */
-    private static long averageTimeForcedToWait;
+    private static long totalTimeUIWaited;
 
     private static void recordTimeUISpentWaitingForNetworkCall(long timeUIWaitingStarted) {
         if (timeUIWaitingStarted == 0 || !SettingsEnum.DEBUG.getBoolean()) {
@@ -319,10 +319,11 @@ public class ReturnYouTubeDislike {
         final long timeUIWaitingTotal = System.currentTimeMillis() - timeUIWaitingStarted;
         LogHelper.printDebug(() -> "UI thread paused for: " + timeUIWaitingTotal + "ms waiting for vote fetch to complete");
 
-        final double weightedOldAverageLoadTime = averageTimeForcedToWait * ((double) numberOfTimesUIWaitedOnNetworkCall / (numberOfTimesUIWaitedOnNetworkCall + 1));
+        totalTimeUIWaited += timeUIWaitingTotal;
         numberOfTimesUIWaitedOnNetworkCall++;
-        final double weightedRecentAverageLoadTime = (double)timeUIWaitingTotal / numberOfTimesUIWaitedOnNetworkCall;
-        averageTimeForcedToWait = (long) (weightedOldAverageLoadTime + weightedRecentAverageLoadTime);
-        LogHelper.printDebug(() -> "UI thread paused: " + numberOfTimesUIWaitedOnNetworkCall + " times, waiting an average time of: " + averageTimeForcedToWait + "ms");
+        final long averageTimeForcedToWait = totalTimeUIWaited / numberOfTimesUIWaitedOnNetworkCall;
+        LogHelper.printDebug(() -> "UI thread forced to wait: " + numberOfTimesUIWaitedOnNetworkCall + " times, "
+                + "waiting a total wait time of: " + totalTimeUIWaited + "ms, "
+                + "with an average time of: " + averageTimeForcedToWait + "ms") ;
     }
 }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -323,7 +323,7 @@ public class ReturnYouTubeDislike {
         numberOfTimesUIWaitedOnNetworkCall++;
         final long averageTimeForcedToWait = totalTimeUIWaited / numberOfTimesUIWaitedOnNetworkCall;
         LogHelper.printDebug(() -> "UI thread forced to wait: " + numberOfTimesUIWaitedOnNetworkCall + " times, "
-                + "waiting a total wait time of: " + totalTimeUIWaited + "ms, "
-                + "with an average time of: " + averageTimeForcedToWait + "ms") ;
+                + "total wait time of: " + totalTimeUIWaited + "ms, "
+                + "average wait time of: " + averageTimeForcedToWait + "ms") ;
     }
 }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -312,11 +312,11 @@ public class ReturnYouTubeDislike {
      */
     private static long totalTimeUIWaitedOnNetworkCalls;
 
-    private static void recordTimeUISpentWaitingForNetworkCall(long timeUIWaitingStarted) {
-        if (timeUIWaitingStarted == 0 || !SettingsEnum.DEBUG.getBoolean()) {
+    private static void recordTimeUISpentWaitingForNetworkCall(long timeUIWaitStarted) {
+        if (timeUIWaitStarted == 0 || !SettingsEnum.DEBUG.getBoolean()) {
             return;
         }
-        final long timeUIWaitingTotal = System.currentTimeMillis() - timeUIWaitingStarted;
+        final long timeUIWaitingTotal = System.currentTimeMillis() - timeUIWaitStarted;
         LogHelper.printDebug(() -> "UI thread paused for: " + timeUIWaitingTotal + "ms waiting for vote fetch to complete");
 
         totalTimeUIWaitedOnNetworkCalls += timeUIWaitingTotal;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -305,12 +305,12 @@ public class ReturnYouTubeDislike {
     /**
      * Number of times the UI was forced to wait on a network fetch to complete
      */
-    private static int numberOfTimesUIWaitedOnNetworkCalls;
+    private static volatile int numberOfTimesUIWaitedOnNetworkCalls;
 
     /**
      * Total time the UI waited, of all times it was forced to wait.
      */
-    private static long totalTimeUIWaitedOnNetworkCalls;
+    private static volatile long totalTimeUIWaitedOnNetworkCalls;
 
     private static void recordTimeUISpentWaitingForNetworkCall(long timeUIWaitStarted) {
         if (timeUIWaitStarted == 0 || !SettingsEnum.DEBUG.getBoolean()) {

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -147,10 +147,10 @@ public class ReturnYouTubeDislike {
                 votingData = fetchFuture.get(MILLISECONDS_TO_BLOCK_UI_WHILE_WAITING_FOR_DISLIKE_FETCH_TO_COMPLETE, TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
                 LogHelper.printDebug(() -> "UI timed out waiting for dislike fetch to complete");
-                recordTimeUISpentWaitingForNetworkCall(fetchStartTime);
                 return;
+            } finally {
+                recordTimeUISpentWaitingForNetworkCall(fetchStartTime);
             }
-            recordTimeUISpentWaitingForNetworkCall(fetchStartTime);
             if (votingData == null) {
                 LogHelper.printDebug(() -> "Cannot add dislike count to UI (RYD data not available)");
                 return;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -31,6 +31,8 @@ public class ReturnYouTubeDislikeApi {
 
     /**
      * Default connection and response timeout for {@link #fetchVotes(String)}
+     *
+     * To locally debug and force timeouts, change this to a very small number (ie: 100)
      */
     private static final int API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS = 4000;
 
@@ -171,7 +173,7 @@ public class ReturnYouTubeDislikeApi {
         // set to true, to verify rate limit works
         final boolean DEBUG_RATE_LIMIT = false;
         if (DEBUG_RATE_LIMIT) {
-            final double RANDOM_RATE_LIMIT_PERCENTAGE = 0.1; // 10% chance of a triggering a rate limit
+            final double RANDOM_RATE_LIMIT_PERCENTAGE = 0.2; // 20% chance of a triggering a rate limit
             if (Math.random() < RANDOM_RATE_LIMIT_PERCENTAGE) {
                 LogHelper.printDebug(() -> "Artificially triggering rate limit for debug purposes");
                 httpResponseCode = RATE_LIMIT_HTTP_STATUS_CODE;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -27,11 +27,15 @@ import app.revanced.integrations.utils.ReVancedUtils;
 
 public class ReturnYouTubeDislikeApi {
     /**
-     * {@link #fetchVotes(String)} TCP connection and HTTP read timeout
-     *
-     * To locally debug and force timeouts, change this to a very small number (ie: 100)
+     * {@link #fetchVotes(String)} TCP connection timeout
      */
-    private static final int API_GET_DISLIKE_TIMEOUT_MILLISECONDS = 4000;
+    private static final int API_GET_VOTES_TCP_TIMEOUT_MILLISECONDS = 2000;
+
+    /**
+     * {@link #fetchVotes(String)} HTTP read timeout
+     *  To locally debug and force timeouts, change this to a very small number (ie: 100)
+     */
+    private static final int API_GET_VOTES_HTTP_TIMEOUT_MILLISECONDS = 4000;
 
     /**
      * Default connection and response timeout for voting and registration.
@@ -234,10 +238,10 @@ public class ReturnYouTubeDislikeApi {
             connection.setRequestProperty("Pragma", "no-cache");
             connection.setRequestProperty("Cache-Control", "no-cache");
             connection.setUseCaches(false);
-            connection.setConnectTimeout(API_GET_DISLIKE_TIMEOUT_MILLISECONDS); // timeout for TCP connection to server
-            connection.setReadTimeout(API_GET_DISLIKE_TIMEOUT_MILLISECONDS); // timeout for server response
+            connection.setConnectTimeout(API_GET_VOTES_TCP_TIMEOUT_MILLISECONDS); // timeout for TCP connection to server
+            connection.setReadTimeout(API_GET_VOTES_HTTP_TIMEOUT_MILLISECONDS); // timeout for server response
 
-            randomlyWaitIfLocallyDebugging(2 * API_GET_DISLIKE_TIMEOUT_MILLISECONDS);
+            randomlyWaitIfLocallyDebugging(2*(API_GET_VOTES_TCP_TIMEOUT_MILLISECONDS + API_GET_VOTES_HTTP_TIMEOUT_MILLISECONDS));
 
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -205,11 +205,11 @@ public class ReturnYouTubeDislikeApi {
         if (timedOut) {
             fetchCallResponseTimeLast = FETCH_CALL_RESPONSE_TIME_VALUE_TIMEOUT;
             fetchCallNumberOfFailures++;
-            showToast("revanced_ryd_connection_timeout_message");
+            showToast("revanced_ryd_failure_connection_timeout");
         } else if (rateLimitHit) {
             fetchCallResponseTimeLast = FETCH_CALL_RESPONSE_TIME_VALUE_RATE_LIMIT;
             numberOfRateLimitRequestsEncountered++;
-            showToast("revanced_ryd_client_rate_limit_requested");
+            showToast("revanced_ryd_failure_client_rate_limit_requested");
         } else {
             fetchCallResponseTimeLast = responseTimeOfFetchCall;
         }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -241,13 +241,14 @@ public class ReturnYouTubeDislikeApi {
 
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
-                connection.disconnect();
+                connection.disconnect(); // rate limit hit, should disconnect
                 updateStatistics(timeNetworkCallStarted, false, true);
                 return null;
             }
 
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                JSONObject json = Requester.getJSONObject(connection); // also disconnects
+                // do not disconnect, the same server connection will likely be used again soon
+                JSONObject json = Requester.getJSONObject(connection, false);
                 try {
                     RYDVoteData votingData = new RYDVoteData(json);
                     updateStatistics(timeNetworkCallStarted, false, false);
@@ -260,7 +261,7 @@ public class ReturnYouTubeDislikeApi {
             } else {
                 LogHelper.printDebug(() -> "Failed to fetch dislikes for video: " + videoId
                         + " response code was: " + responseCode);
-                connection.disconnect();
+                connection.disconnect(); // something went wrong, might as well disconnect
             }
         } catch (Exception ex) { // connection timed out, response timeout, or some other network error
             LogHelper.printException(() -> "Failed to fetch dislikes", ex);
@@ -290,11 +291,11 @@ public class ReturnYouTubeDislikeApi {
 
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
-                connection.disconnect();
+                connection.disconnect(); // disconnect, as no more connections will be made for a little while
                 return null;
             }
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                JSONObject json = Requester.getJSONObject(connection);  // also disconnects
+                JSONObject json = Requester.getJSONObject(connection, false);
                 String challenge = json.getString("challenge");
                 int difficulty = json.getInt("difficulty");
 
@@ -332,11 +333,11 @@ public class ReturnYouTubeDislikeApi {
             }
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
-                connection.disconnect();
+                connection.disconnect(); // disconnect, as no more connections will be made for a little while
                 return null;
             }
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                String result = Requester.parseJson(connection); // also disconnects
+                String result = Requester.parseJson(connection, false);
                 if (result.equalsIgnoreCase("true")) {
                     LogHelper.printDebug(() -> "Registration confirmation successful for user: " + userId);
                     return userId;
@@ -346,8 +347,8 @@ public class ReturnYouTubeDislikeApi {
             } else {
                 LogHelper.printDebug(() -> "Failed to confirm registration for user: " + userId
                         + " solution: " + solution + " response code was: " + responseCode);
-                connection.disconnect();
             }
+            connection.disconnect(); // something went wrong, might as well disconnect
         } catch (Exception ex) {
             LogHelper.printException(() -> "Failed to confirm registration for user: " + userId
                     + "solution: " + solution, ex);
@@ -381,11 +382,11 @@ public class ReturnYouTubeDislikeApi {
 
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
-                connection.disconnect();
+                connection.disconnect(); // disconnect, as no more connections will be made for a little while
                 return false;
             }
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                JSONObject json = Requester.getJSONObject(connection);  // also disconnects
+                JSONObject json = Requester.getJSONObject(connection, false);
                 String challenge = json.getString("challenge");
                 int difficulty = json.getInt("difficulty");
 
@@ -394,7 +395,7 @@ public class ReturnYouTubeDislikeApi {
             }
             LogHelper.printDebug(() -> "Failed to send vote for video: " + videoId
                     + " userId: " + userId + " vote: " + vote + " response code was: " + responseCode);
-            connection.disconnect();
+            connection.disconnect(); // something went wrong, might as well disconnect
         } catch (Exception ex) {
             LogHelper.printException(() -> "Failed to send vote for video: " + videoId
                     + " user: " + userId + " vote: " + vote, ex);
@@ -425,12 +426,12 @@ public class ReturnYouTubeDislikeApi {
             }
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
-                connection.disconnect();
+                connection.disconnect(); // disconnect, as no more connections will be made for a little while
                 return false;
             }
 
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                String result = Requester.parseJson(connection); // also disconnects
+                String result = Requester.parseJson(connection, false);
                 if (result.equalsIgnoreCase("true")) {
                     LogHelper.printDebug(() -> "Vote confirm successful for video: " + videoId);
                     return true;
@@ -440,8 +441,8 @@ public class ReturnYouTubeDislikeApi {
             } else {
                 LogHelper.printDebug(() -> "Failed to confirm vote for video: " + videoId
                         + " user: " + userId + " solution: " + solution + " response code was: " + responseCode);
-                connection.disconnect();
             }
+            connection.disconnect(); // something went wrong, might as well disconnect
         } catch (Exception ex) {
             LogHelper.printException(() -> "Failed to confirm vote for video: " + videoId
                     + " user: " + userId + " solution: " + solution, ex);

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -220,10 +220,10 @@ public class ReturnYouTubeDislikeApi {
         ReVancedUtils.verifyOffMainThread();
         Objects.requireNonNull(videoId);
 
-        if (checkIfRateLimitInEffect("fetchDislikes")) {
+        if (checkIfRateLimitInEffect("fetchVotes")) {
             return null;
         }
-        LogHelper.printDebug(() -> "Fetching dislikes for: " + videoId);
+        LogHelper.printDebug(() -> "Fetching votes for: " + videoId);
         final long timeNetworkCallStarted = System.currentTimeMillis();
 
         try {
@@ -261,12 +261,12 @@ public class ReturnYouTubeDislikeApi {
                     // fall thru to update statistics
                 }
             } else {
-                LogHelper.printDebug(() -> "Failed to fetch dislikes for video: " + videoId
+                LogHelper.printDebug(() -> "Failed to fetch votes for video: " + videoId
                         + " response code was: " + responseCode);
                 connection.disconnect(); // something went wrong, might as well disconnect
             }
         } catch (Exception ex) { // connection timed out, response timeout, or some other network error
-            LogHelper.printException(() -> "Failed to fetch dislikes", ex);
+            LogHelper.printException(() -> "Failed to fetch votes", ex);
         }
 
         updateStatistics(timeNetworkCallStarted, System.currentTimeMillis(), true, false);

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -71,7 +71,8 @@ public class ReturnYouTubeDislikeApi {
     private static volatile int numberOfRateLimitRequestsEncountered;
 
     /**
-     * Number of times calls {@link #fetchVotes(String)} fails due to timeout or any other error.
+     * Number of times {@link #fetchVotes(String)} failed due to timeout or any other error.
+     * This does not include when rate limit requests are encountered.
      */
     private static volatile int fetchCallNumberOfFailedCalls;
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -1,5 +1,6 @@
 package app.revanced.integrations.returnyoutubedislike.requests;
 
+import static app.revanced.integrations.returnyoutubedislike.requests.ReturnYouTubeDislikeRoutes.getRYDConnectionFromRoute;
 import static app.revanced.integrations.sponsorblock.StringRef.str;
 
 import android.util.Base64;
@@ -10,7 +11,6 @@ import androidx.annotation.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
@@ -21,14 +21,11 @@ import java.security.SecureRandom;
 import java.util.Objects;
 
 import app.revanced.integrations.requests.Requester;
-import app.revanced.integrations.requests.Route;
 import app.revanced.integrations.returnyoutubedislike.ReturnYouTubeDislike;
 import app.revanced.integrations.utils.LogHelper;
 import app.revanced.integrations.utils.ReVancedUtils;
 
 public class ReturnYouTubeDislikeApi {
-    private static final String RYD_API_URL = "https://returnyoutubedislikeapi.com/";
-
     /**
      * Default connection and response timeout for {@link #fetchVotes(String)}
      *
@@ -287,7 +284,7 @@ public class ReturnYouTubeDislikeApi {
             String userId = randomString(36);
             LogHelper.printDebug(() -> "Trying to register new user: " + userId);
 
-            HttpURLConnection connection = getConnectionFromRoute(ReturnYouTubeDislikeRoutes.GET_REGISTRATION, userId);
+            HttpURLConnection connection = getRYDConnectionFromRoute(ReturnYouTubeDislikeRoutes.GET_REGISTRATION, userId);
             connection.setRequestProperty("Accept", "application/json");
             connection.setConnectTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS);
             connection.setReadTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS);
@@ -326,7 +323,7 @@ public class ReturnYouTubeDislikeApi {
             }
             LogHelper.printDebug(() -> "Trying to confirm registration for user: " + userId + " with solution: " + solution);
 
-            HttpURLConnection connection = getConnectionFromRoute(ReturnYouTubeDislikeRoutes.CONFIRM_REGISTRATION, userId);
+            HttpURLConnection connection = getRYDConnectionFromRoute(ReturnYouTubeDislikeRoutes.CONFIRM_REGISTRATION, userId);
             applyCommonPostRequestSettings(connection);
 
             String jsonInputString = "{\"solution\": \"" + solution + "\"}";
@@ -374,7 +371,7 @@ public class ReturnYouTubeDislikeApi {
             LogHelper.printDebug(() -> "Trying to vote for video: "
                     + videoId + " with vote: " + vote + " user: " + userId);
 
-            HttpURLConnection connection = getConnectionFromRoute(ReturnYouTubeDislikeRoutes.SEND_VOTE);
+            HttpURLConnection connection = getRYDConnectionFromRoute(ReturnYouTubeDislikeRoutes.SEND_VOTE);
             applyCommonPostRequestSettings(connection);
 
             String voteJsonString = "{\"userId\": \"" + userId + "\", \"videoId\": \"" + videoId + "\", \"value\": \"" + vote.value + "\"}";
@@ -419,7 +416,7 @@ public class ReturnYouTubeDislikeApi {
             }
             LogHelper.printDebug(() -> "Trying to confirm vote for video: "
                     + videoId + " user: " + userId + " solution: " + solution);
-            HttpURLConnection connection = getConnectionFromRoute(ReturnYouTubeDislikeRoutes.CONFIRM_VOTE);
+            HttpURLConnection connection = getRYDConnectionFromRoute(ReturnYouTubeDislikeRoutes.CONFIRM_VOTE);
             applyCommonPostRequestSettings(connection);
 
             String jsonInputString = "{\"userId\": \"" + userId + "\", \"videoId\": \"" + videoId + "\", \"solution\": \"" + solution + "\"}";
@@ -472,9 +469,6 @@ public class ReturnYouTubeDislikeApi {
         connection.setReadTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS); // timeout for server response
     }
 
-    private static HttpURLConnection getConnectionFromRoute(Route route, String... params) throws IOException {
-        return Requester.getConnectionFromRoute(RYD_API_URL, route, params);
-    }
 
     private static String solvePuzzle(String challenge, int difficulty) {
         final long timeSolveStarted = System.currentTimeMillis();

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -27,11 +27,11 @@ import app.revanced.integrations.utils.ReVancedUtils;
 
 public class ReturnYouTubeDislikeApi {
     /**
-     * Default connection and response timeout for {@link #fetchVotes(String)}
+     * {@link #fetchVotes(String)} TCP connection and HTTP read timeout
      *
      * To locally debug and force timeouts, change this to a very small number (ie: 100)
      */
-    private static final int API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS = 4000;
+    private static final int API_GET_DISLIKE_TIMEOUT_MILLISECONDS = 4000;
 
     /**
      * Default connection and response timeout for voting and registration.
@@ -39,7 +39,7 @@ public class ReturnYouTubeDislikeApi {
      * Voting and user registration runs in the background and has has no urgency
      * so this can be a larger value.
      */
-    private static final int API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS = 90000;
+    private static final int API_REGISTER_VOTE_TIMEOUT_MILLISECONDS = 90000;
 
     /**
      * Response code of a successful API call
@@ -127,13 +127,13 @@ public class ReturnYouTubeDislikeApi {
     } // utility class
 
     /**
-     * Only for local debugging to simulate a slow api call.
-     * Does this by doing meaningless calculations.
+     * Only to simulate a slow api call, for debugging the app UI with slow url calls.
+     * Simulates a slow response by doing meaningless calculations.
      *
      * @param maximumTimeToWait maximum time to wait
      */
     private static long randomlyWaitIfLocallyDebugging(long maximumTimeToWait) {
-        final boolean DEBUG_RANDOMLY_DELAY_NETWORK_CALLS = false;
+        final boolean DEBUG_RANDOMLY_DELAY_NETWORK_CALLS = false; // set true to debug UI
         if (DEBUG_RANDOMLY_DELAY_NETWORK_CALLS) {
             final long amountOfTimeToWaste = (long) (Math.random() * maximumTimeToWait);
             final long timeCalculationStarted = System.currentTimeMillis();
@@ -171,8 +171,7 @@ public class ReturnYouTubeDislikeApi {
      * @return True, if a client rate limit was requested
      */
     private static boolean checkIfRateLimitWasHit(int httpResponseCode) {
-        // set to true, to verify rate limit works
-        final boolean DEBUG_RATE_LIMIT = false;
+        final boolean DEBUG_RATE_LIMIT = false;  // set to true, to verify rate limit works
         if (DEBUG_RATE_LIMIT) {
             final double RANDOM_RATE_LIMIT_PERCENTAGE = 0.2; // 20% chance of a triggering a rate limit
             if (Math.random() < RANDOM_RATE_LIMIT_PERCENTAGE) {
@@ -235,10 +234,10 @@ public class ReturnYouTubeDislikeApi {
             connection.setRequestProperty("Pragma", "no-cache");
             connection.setRequestProperty("Cache-Control", "no-cache");
             connection.setUseCaches(false);
-            connection.setConnectTimeout(API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS); // timeout for TCP connection to server
-            connection.setReadTimeout(API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS); // timeout for server response
+            connection.setConnectTimeout(API_GET_DISLIKE_TIMEOUT_MILLISECONDS); // timeout for TCP connection to server
+            connection.setReadTimeout(API_GET_DISLIKE_TIMEOUT_MILLISECONDS); // timeout for server response
 
-            randomlyWaitIfLocallyDebugging(2 * API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS);
+            randomlyWaitIfLocallyDebugging(2 * API_GET_DISLIKE_TIMEOUT_MILLISECONDS);
 
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
@@ -286,8 +285,8 @@ public class ReturnYouTubeDislikeApi {
 
             HttpURLConnection connection = getRYDConnectionFromRoute(ReturnYouTubeDislikeRoutes.GET_REGISTRATION, userId);
             connection.setRequestProperty("Accept", "application/json");
-            connection.setConnectTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS);
-            connection.setReadTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS);
+            connection.setConnectTimeout(API_REGISTER_VOTE_TIMEOUT_MILLISECONDS);
+            connection.setReadTimeout(API_REGISTER_VOTE_TIMEOUT_MILLISECONDS);
 
             final int responseCode = connection.getResponseCode();
             if (checkIfRateLimitWasHit(responseCode)) {
@@ -465,8 +464,8 @@ public class ReturnYouTubeDislikeApi {
         connection.setRequestProperty("Cache-Control", "no-cache");
         connection.setUseCaches(false);
         connection.setDoOutput(true);
-        connection.setConnectTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS); // timeout for TCP connection to server
-        connection.setReadTimeout(API_REGISTER_VOTE_DEFAULT_TIMEOUT_MILLISECONDS); // timeout for server response
+        connection.setConnectTimeout(API_REGISTER_VOTE_TIMEOUT_MILLISECONDS); // timeout for TCP connection to server
+        connection.setReadTimeout(API_REGISTER_VOTE_TIMEOUT_MILLISECONDS); // timeout for server response
     }
 
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -230,12 +230,7 @@ public class ReturnYouTubeDislikeApi {
         final long timeNetworkCallStarted = System.currentTimeMillis();
 
         try {
-            if (checkIfRateLimitInEffect("fetchDislikes")) {
-                return null;
-            }
-            LogHelper.printDebug(() -> "Fetching dislikes for: " + videoId);
-
-            HttpURLConnection connection = getConnectionFromRoute(ReturnYouTubeDislikeRoutes.GET_DISLIKES, videoId);
+            HttpURLConnection connection = getRYDConnectionFromRoute(ReturnYouTubeDislikeRoutes.GET_DISLIKES, videoId);
             // request headers, as per https://returnyoutubedislike.com/docs/fetching
             // the documentation says to use 'Accept:text/html', but the RYD browser plugin uses 'Accept:application/json'
             connection.setRequestProperty("Accept", "application/json");

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -223,7 +223,12 @@ public class ReturnYouTubeDislikeApi {
         ReVancedUtils.verifyOffMainThread();
         Objects.requireNonNull(videoId);
 
+        if (checkIfRateLimitInEffect("fetchDislikes")) {
+            return null;
+        }
+        LogHelper.printDebug(() -> "Fetching dislikes for: " + videoId);
         final long timeNetworkCallStarted = System.currentTimeMillis();
+
         try {
             if (checkIfRateLimitInEffect("fetchDislikes")) {
                 return null;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -32,7 +32,7 @@ public class ReturnYouTubeDislikeApi {
     /**
      * Default connection and response timeout for {@link #fetchVotes(String)}
      */
-    private static final int API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS = 5000;
+    private static final int API_GET_DISLIKE_DEFAULT_TIMEOUT_MILLISECONDS = 4000;
 
     /**
      * Default connection and response timeout for voting and registration.

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -193,16 +193,16 @@ public class ReturnYouTubeDislikeApi {
         return false;
     }
 
-    private static void updateStatistics(long timeNetworkCallStarted, boolean timedOut, boolean rateLimitHit) {
-        if (timedOut && rateLimitHit) {
-            throw new IllegalArgumentException("both timeout and rate limit parameter were true");
+    private static void updateStatistics(long timeNetworkCallStarted, boolean connectionError, boolean rateLimitHit) {
+        if (connectionError && rateLimitHit) {
+            throw new IllegalArgumentException("both connection error and rate limit parameter were true");
         }
         final long responseTimeOfFetchCall = System.currentTimeMillis() - timeNetworkCallStarted;
         fetchCallResponseTimeTotal += responseTimeOfFetchCall;
         fetchCallResponseTimeMin = (fetchCallResponseTimeMin == 0) ? responseTimeOfFetchCall : Math.min(responseTimeOfFetchCall, fetchCallResponseTimeMin);
         fetchCallResponseTimeMax = Math.max(responseTimeOfFetchCall, fetchCallResponseTimeMax);
         fetchCallCount++;
-        if (timedOut) {
+        if (connectionError) {
             fetchCallResponseTimeLast = FETCH_CALL_RESPONSE_TIME_VALUE_TIMEOUT;
             fetchCallNumberOfFailures++;
             showToast("revanced_ryd_failure_connection_timeout");
@@ -259,7 +259,7 @@ public class ReturnYouTubeDislikeApi {
                     return votingData;
                 } catch (JSONException ex) {
                     LogHelper.printException(() -> "Failed to parse video: " + videoId + " json: " + json, ex);
-                    // should never be reached, but fall thru to show a toast in code below
+                    // fall thru to update statistics
                 }
             } else {
                 LogHelper.printDebug(() -> "Failed to fetch dislikes for video: " + videoId

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -248,7 +248,7 @@ public class ReturnYouTubeDislikeApi {
 
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
                 // do not disconnect, the same server connection will likely be used again soon
-                JSONObject json = Requester.getJSONObject(connection, false);
+                JSONObject json = Requester.parseJSONObject(connection);
                 try {
                     RYDVoteData votingData = new RYDVoteData(json);
                     updateStatistics(timeNetworkCallStarted, false, false);
@@ -295,7 +295,7 @@ public class ReturnYouTubeDislikeApi {
                 return null;
             }
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                JSONObject json = Requester.getJSONObject(connection, false);
+                JSONObject json = Requester.parseJSONObject(connection);
                 String challenge = json.getString("challenge");
                 int difficulty = json.getInt("difficulty");
 
@@ -337,7 +337,7 @@ public class ReturnYouTubeDislikeApi {
                 return null;
             }
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                String result = Requester.parseJson(connection, false);
+                String result = Requester.parseJson(connection);
                 if (result.equalsIgnoreCase("true")) {
                     LogHelper.printDebug(() -> "Registration confirmation successful for user: " + userId);
                     return userId;
@@ -386,7 +386,7 @@ public class ReturnYouTubeDislikeApi {
                 return false;
             }
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                JSONObject json = Requester.getJSONObject(connection, false);
+                JSONObject json = Requester.parseJSONObject(connection);
                 String challenge = json.getString("challenge");
                 int difficulty = json.getInt("difficulty");
 
@@ -431,7 +431,7 @@ public class ReturnYouTubeDislikeApi {
             }
 
             if (responseCode == SUCCESS_HTTP_STATUS_CODE) {
-                String result = Requester.parseJson(connection, false);
+                String result = Requester.parseJson(connection);
                 if (result.equalsIgnoreCase("true")) {
                     LogHelper.printDebug(() -> "Vote confirm successful for video: " + videoId);
                     return true;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -311,6 +311,7 @@ public class ReturnYouTubeDislikeApi {
         } catch (Exception ex) {
             LogHelper.printException(() -> "Failed to register user", ex);
         }
+        showToast("revanced_ryd_failure_register_user");
         return null;
     }
 
@@ -346,15 +347,16 @@ public class ReturnYouTubeDislikeApi {
                 }
                 LogHelper.printDebug(() -> "Failed to confirm registration for user: " + userId
                         + " solution: " + solution + " response string was: " + result);
-                return null;
+            } else {
+                LogHelper.printDebug(() -> "Failed to confirm registration for user: " + userId
+                        + " solution: " + solution + " response code was: " + responseCode);
+                connection.disconnect();
             }
-            LogHelper.printDebug(() -> "Failed to confirm registration for user: " + userId
-                    + " solution: " + solution + " response code was: " + responseCode);
-            connection.disconnect();
         } catch (Exception ex) {
             LogHelper.printException(() -> "Failed to confirm registration for user: " + userId
                     + "solution: " + solution, ex);
         }
+        showToast("revanced_ryd_failure_confirm_user");
 
         return null;
     }
@@ -401,6 +403,7 @@ public class ReturnYouTubeDislikeApi {
             LogHelper.printException(() -> "Failed to send vote for video: " + videoId
                     + " user: " + userId + " vote: " + vote, ex);
         }
+        showToast("revanced_ryd_failure_send_vote_failed");
         return false;
     }
 
@@ -438,15 +441,16 @@ public class ReturnYouTubeDislikeApi {
                 }
                 LogHelper.printDebug(() -> "Failed to confirm vote for video: " + videoId
                         + " user: " + userId + " solution: " + solution + " response string was: " + result);
-                return false;
+            } else {
+                LogHelper.printDebug(() -> "Failed to confirm vote for video: " + videoId
+                        + " user: " + userId + " solution: " + solution + " response code was: " + responseCode);
+                connection.disconnect();
             }
-            LogHelper.printDebug(() -> "Failed to confirm vote for video: " + videoId
-                    + " user: " + userId + " solution: " + solution + " response code was: " + responseCode);
-            connection.disconnect();
         } catch (Exception ex) {
             LogHelper.printException(() -> "Failed to confirm vote for video: " + videoId
                     + " user: " + userId + " solution: " + solution, ex);
         }
+        showToast("revanced_ryd_failure_confirm_vote_failed");
         return false;
     }
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeRoutes.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeRoutes.java
@@ -3,15 +3,26 @@ package app.revanced.integrations.returnyoutubedislike.requests;
 import static app.revanced.integrations.requests.Route.Method.GET;
 import static app.revanced.integrations.requests.Route.Method.POST;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import app.revanced.integrations.requests.Requester;
 import app.revanced.integrations.requests.Route;
 
-public class ReturnYouTubeDislikeRoutes {
-    public static final Route SEND_VOTE = new Route(POST, "interact/vote");
-    public static final Route CONFIRM_VOTE = new Route(POST, "interact/confirmVote");
-    public static final Route GET_DISLIKES = new Route(GET, "votes?videoId={video_id}");
-    public static final Route GET_REGISTRATION = new Route(GET, "puzzle/registration?userId={user_id}");
-    public static final Route CONFIRM_REGISTRATION = new Route(POST, "puzzle/registration?userId={user_id}");
+class ReturnYouTubeDislikeRoutes {
+    static final String RYD_API_URL = "https://returnyoutubedislikeapi.com/";
+
+    static final Route SEND_VOTE = new Route(POST, "interact/vote");
+    static final Route CONFIRM_VOTE = new Route(POST, "interact/confirmVote");
+    static final Route GET_DISLIKES = new Route(GET, "votes?videoId={video_id}");
+    static final Route GET_REGISTRATION = new Route(GET, "puzzle/registration?userId={user_id}");
+    static final Route CONFIRM_REGISTRATION = new Route(POST, "puzzle/registration?userId={user_id}");
 
     private ReturnYouTubeDislikeRoutes() {
     }
+
+    static HttpURLConnection getRYDConnectionFromRoute(Route route, String... params) throws IOException {
+        return Requester.getConnectionFromRoute(RYD_API_URL, route, params);
+    }
+
 }

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -149,20 +149,28 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailedCalls_title"));
-            final int fetchCallNumberOfFailedCalls = ReturnYouTubeDislikeApi.getFetchCallNumberOfFailedCalls();
-            String fetchFailedSummary = fetchCallNumberOfFailedCalls == 0
-                    ? str("revanced_ryd_connection_statistics_fetchCallNumberOfFailedCalls_zero_summary")
-                    : String.valueOf(fetchCallNumberOfFailedCalls);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_title"));
+            final int fetchCallNumberOfFailures = ReturnYouTubeDislikeApi.getFetchCallNumberOfFailures();
+            String fetchFailedSummary;
+            if (fetchCallNumberOfFailures == 0) {
+                fetchFailedSummary = str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_zero_summary");
+            } else {
+                String formatString = str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_non_zero_summary");
+                fetchFailedSummary = String.format(formatString, fetchCallNumberOfFailures);
+            }
             statisticPreference.setSummary(fetchFailedSummary);
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_title"));
             final int numberOfRateLimitRequestsEncountered = ReturnYouTubeDislikeApi.getNumberOfRateLimitRequestsEncountered();
-            String rateLimitSummary = numberOfRateLimitRequestsEncountered == 0
-                    ? str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary")
-                    : String.valueOf(numberOfRateLimitRequestsEncountered);
+            String rateLimitSummary;
+            if (numberOfRateLimitRequestsEncountered == 0) {
+                rateLimitSummary = str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary");
+            } else {
+                String formatString = str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_non_zero_summary");
+                rateLimitSummary = String.format(formatString, numberOfRateLimitRequestsEncountered);
+            }
             statisticPreference.setSummary(rateLimitSummary);
             preferenceScreen.addPreference(statisticPreference);
         }

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -136,8 +136,6 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             final long fetchCallTimeWaitingLast = ReturnYouTubeDislikeApi.getFetchCallResponseTimeLast();
             if (fetchCallTimeWaitingLast == ReturnYouTubeDislikeApi.FETCH_CALL_RESPONSE_TIME_VALUE_RATE_LIMIT) {
                 fetchCallTimeWaitingLastSummary = str("revanced_ryd_statistics_getFetchCallResponseTimeLast_rate_limit_summary");
-            } else if (fetchCallTimeWaitingLast == ReturnYouTubeDislikeApi.FETCH_CALL_RESPONSE_TIME_VALUE_TIMEOUT) {
-                fetchCallTimeWaitingLastSummary = str("revanced_ryd_statistics_getFetchCallResponseTimeLast_timeout_summary");
             } else {
                 fetchCallTimeWaitingLastSummary = createMillisecondStringFromNumber(fetchCallTimeWaitingLast);
             }

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -105,7 +105,7 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
         // RYD API connection statistics
         
         if (SettingsEnum.DEBUG.getBoolean()) {
-            PreferenceCategory emptyCategory = new PreferenceCategory(context);
+            PreferenceCategory emptyCategory = new PreferenceCategory(context); // vertical padding
             preferenceScreen.addPreference(emptyCategory);
 
             PreferenceCategory statisticsCategory = new PreferenceCategory(context);
@@ -145,35 +145,32 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
 
             statisticPreference = new Preference(context);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallCount_title"));
-            statisticPreference.setSummary(String.valueOf(ReturnYouTubeDislikeApi.getFetchCallCount()));
+            statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getFetchCallCount(),
+                    "revanced_ryd_connection_statistics_getFetchCallCount_zero_summary",
+                    "revanced_ryd_connection_statistics_getFetchCallCount_non_zero_summary"));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_title"));
-            final int fetchCallNumberOfFailures = ReturnYouTubeDislikeApi.getFetchCallNumberOfFailures();
-            String fetchFailedSummary;
-            if (fetchCallNumberOfFailures == 0) {
-                fetchFailedSummary = str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_zero_summary");
-            } else {
-                String formatString = str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_non_zero_summary");
-                fetchFailedSummary = String.format(formatString, fetchCallNumberOfFailures);
-            }
-            statisticPreference.setSummary(fetchFailedSummary);
+            statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getFetchCallNumberOfFailures(),
+                    "revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_zero_summary",
+                    "revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_non_zero_summary"));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_title"));
-            final int numberOfRateLimitRequestsEncountered = ReturnYouTubeDislikeApi.getNumberOfRateLimitRequestsEncountered();
-            String rateLimitSummary;
-            if (numberOfRateLimitRequestsEncountered == 0) {
-                rateLimitSummary = str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary");
-            } else {
-                String formatString = str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_non_zero_summary");
-                rateLimitSummary = String.format(formatString, numberOfRateLimitRequestsEncountered);
-            }
-            statisticPreference.setSummary(rateLimitSummary);
+            statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getNumberOfRateLimitRequestsEncountered(),
+                    "revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary",
+                    "revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_non_zero_summary"));
             preferenceScreen.addPreference(statisticPreference);
         }
+    }
+
+    private String createSummaryText(int value, String summaryStringZeroKey, String summaryStringOneOrMoreKey) {
+        if (value == 0) {
+            return str(summaryStringZeroKey);
+        }
+        return String.format(str(summaryStringOneOrMoreKey), value);
     }
 
     private static String createMillisecondStringFromNumber(long number) {

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -109,66 +109,66 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             preferenceScreen.addPreference(emptyCategory);
 
             PreferenceCategory statisticsCategory = new PreferenceCategory(context);
-            statisticsCategory.setTitle(str("revanced_ryd_connection_statistics_category_title"));
+            statisticsCategory.setTitle(str("revanced_ryd_statistics_category_title"));
             preferenceScreen.addPreference(statisticsCategory);
 
             Preference statisticPreference;
 
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeAverage_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getFetchCallResponseTimeAverage_title"));
             statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeAverage()));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeMin_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getFetchCallResponseTimeMin_title"));
             statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeMin()));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeMax_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getFetchCallResponseTimeMax_title"));
             statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeMax()));
             preferenceScreen.addPreference(statisticPreference);
 
             String fetchCallTimeWaitingLastSummary;
             final long fetchCallTimeWaitingLast = ReturnYouTubeDislikeApi.getFetchCallResponseTimeLast();
             if (fetchCallTimeWaitingLast == ReturnYouTubeDislikeApi.FETCH_CALL_RESPONSE_TIME_VALUE_RATE_LIMIT) {
-                fetchCallTimeWaitingLastSummary = str("revanced_ryd_connection_statistics_api_call_rate_limit_in_effect_text");
+                fetchCallTimeWaitingLastSummary = str("revanced_ryd_statistics_getFetchCallResponseTimeLast_rate_limit_summary");
             } else if (fetchCallTimeWaitingLast == ReturnYouTubeDislikeApi.FETCH_CALL_RESPONSE_TIME_VALUE_TIMEOUT) {
-                fetchCallTimeWaitingLastSummary = str("revanced_ryd_connection_statistics_api_call_timeout_text");
+                fetchCallTimeWaitingLastSummary = str("revanced_ryd_statistics_getFetchCallResponseTimeLast_timeout_summary");
             } else {
                 fetchCallTimeWaitingLastSummary = createMillisecondStringFromNumber(fetchCallTimeWaitingLast);
             }
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeLast_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getFetchCallResponseTimeLast_title"));
             statisticPreference.setSummary(fetchCallTimeWaitingLastSummary);
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallCount_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getFetchCallCount_title"));
             statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getFetchCallCount(),
-                    "revanced_ryd_connection_statistics_getFetchCallCount_zero_summary",
-                    "revanced_ryd_connection_statistics_getFetchCallCount_non_zero_summary"));
+                    "revanced_ryd_statistics_getFetchCallCount_zero_summary",
+                    "revanced_ryd_statistics_getFetchCallCount_non_zero_summary"));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getFetchCallNumberOfFailures_title"));
             statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getFetchCallNumberOfFailures(),
-                    "revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_zero_summary",
-                    "revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_non_zero_summary"));
+                    "revanced_ryd_statistics_getFetchCallNumberOfFailures_zero_summary",
+                    "revanced_ryd_statistics_getFetchCallNumberOfFailures_non_zero_summary"));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
             statisticPreference.setSelectable(false);
-            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_title"));
+            statisticPreference.setTitle(str("revanced_ryd_statistics_getNumberOfRateLimitRequestsEncountered_title"));
             statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getNumberOfRateLimitRequestsEncountered(),
-                    "revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary",
-                    "revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_non_zero_summary"));
+                    "revanced_ryd_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary",
+                    "revanced_ryd_statistics_getNumberOfRateLimitRequestsEncountered_non_zero_summary"));
             preferenceScreen.addPreference(statisticPreference);
         }
     }
@@ -181,7 +181,7 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
     }
 
     private static String createMillisecondStringFromNumber(long number) {
-        return number + " " + str("revanced_ryd_connection_statistics_millisecond_text");
+        return number + " " + str("revanced_ryd_statistics_millisecond_text");
     }
 
 }

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -115,16 +115,19 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             Preference statisticPreference;
 
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeAverage_title"));
             statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeAverage()));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeMin_title"));
             statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeMin()));
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeMax_title"));
             statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeMax()));
             preferenceScreen.addPreference(statisticPreference);
@@ -139,11 +142,13 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
                 fetchCallTimeWaitingLastSummary = createMillisecondStringFromNumber(fetchCallTimeWaitingLast);
             }
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeLast_title"));
             statisticPreference.setSummary(fetchCallTimeWaitingLastSummary);
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallCount_title"));
             statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getFetchCallCount(),
                     "revanced_ryd_connection_statistics_getFetchCallCount_zero_summary",
@@ -151,6 +156,7 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_title"));
             statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getFetchCallNumberOfFailures(),
                     "revanced_ryd_connection_statistics_getFetchCallNumberOfFailures_zero_summary",
@@ -158,6 +164,7 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             preferenceScreen.addPreference(statisticPreference);
 
             statisticPreference = new Preference(context);
+            statisticPreference.setSelectable(false);
             statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_title"));
             statisticPreference.setSummary(createSummaryText(ReturnYouTubeDislikeApi.getNumberOfRateLimitRequestsEncountered(),
                     "revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary",

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -181,7 +181,7 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
     }
 
     private static String createMillisecondStringFromNumber(long number) {
-        return number + " " + str("revanced_ryd_statistics_millisecond_text");
+        return String.format(str("revanced_ryd_statistics_millisecond_text"), number);
     }
 
 }

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -13,6 +13,7 @@ import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 
 import app.revanced.integrations.returnyoutubedislike.ReturnYouTubeDislike;
+import app.revanced.integrations.returnyoutubedislike.requests.ReturnYouTubeDislikeApi;
 import app.revanced.integrations.settings.SettingsEnum;
 import app.revanced.integrations.utils.SharedPrefHelper;
 
@@ -100,6 +101,75 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
             return false;
         });
         preferenceScreen.addPreference(aboutWebsitePreference);
+
+        // RYD API connection statistics
+        
+        if (SettingsEnum.DEBUG.getBoolean()) {
+            PreferenceCategory emptyCategory = new PreferenceCategory(context);
+            preferenceScreen.addPreference(emptyCategory);
+
+            PreferenceCategory statisticsCategory = new PreferenceCategory(context);
+            statisticsCategory.setTitle(str("revanced_ryd_connection_statistics_category_title"));
+            preferenceScreen.addPreference(statisticsCategory);
+
+            Preference statisticPreference;
+
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeAverage_title"));
+            statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeAverage()));
+            preferenceScreen.addPreference(statisticPreference);
+
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeMin_title"));
+            statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeMin()));
+            preferenceScreen.addPreference(statisticPreference);
+
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeMax_title"));
+            statisticPreference.setSummary(createMillisecondStringFromNumber(ReturnYouTubeDislikeApi.getFetchCallResponseTimeMax()));
+            preferenceScreen.addPreference(statisticPreference);
+
+            String fetchCallTimeWaitingLastSummary;
+            final long fetchCallTimeWaitingLast = ReturnYouTubeDislikeApi.getFetchCallResponseTimeLast();
+            if (fetchCallTimeWaitingLast == ReturnYouTubeDislikeApi.FETCH_CALL_RESPONSE_TIME_VALUE_RATE_LIMIT) {
+                fetchCallTimeWaitingLastSummary = str("revanced_ryd_connection_statistics_api_call_rate_limit_in_effect_text");
+            } else if (fetchCallTimeWaitingLast == ReturnYouTubeDislikeApi.FETCH_CALL_RESPONSE_TIME_VALUE_TIMEOUT) {
+                fetchCallTimeWaitingLastSummary = str("revanced_ryd_connection_statistics_api_call_timeout_text");
+            } else {
+                fetchCallTimeWaitingLastSummary = createMillisecondStringFromNumber(fetchCallTimeWaitingLast);
+            }
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallResponseTimeLast_title"));
+            statisticPreference.setSummary(fetchCallTimeWaitingLastSummary);
+            preferenceScreen.addPreference(statisticPreference);
+
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallCount_title"));
+            statisticPreference.setSummary(String.valueOf(ReturnYouTubeDislikeApi.getFetchCallCount()));
+            preferenceScreen.addPreference(statisticPreference);
+
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getFetchCallNumberOfFailedCalls_title"));
+            final int fetchCallNumberOfFailedCalls = ReturnYouTubeDislikeApi.getFetchCallNumberOfFailedCalls();
+            String fetchFailedSummary = fetchCallNumberOfFailedCalls == 0
+                    ? str("revanced_ryd_connection_statistics_fetchCallNumberOfFailedCalls_zero_summary")
+                    : String.valueOf(fetchCallNumberOfFailedCalls);
+            statisticPreference.setSummary(fetchFailedSummary);
+            preferenceScreen.addPreference(statisticPreference);
+
+            statisticPreference = new Preference(context);
+            statisticPreference.setTitle(str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_title"));
+            final int numberOfRateLimitRequestsEncountered = ReturnYouTubeDislikeApi.getNumberOfRateLimitRequestsEncountered();
+            String rateLimitSummary = numberOfRateLimitRequestsEncountered == 0
+                    ? str("revanced_ryd_connection_statistics_getNumberOfRateLimitRequestsEncountered_zero_summary")
+                    : String.valueOf(numberOfRateLimitRequestsEncountered);
+            statisticPreference.setSummary(rateLimitSummary);
+            preferenceScreen.addPreference(statisticPreference);
+        }
+    }
+
+    private static String createMillisecondStringFromNumber(long number) {
+        return number + " " + str("revanced_ryd_connection_statistics_millisecond_text");
     }
 
 }

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
@@ -46,7 +46,11 @@ public class SBRequester {
             runVipCheck();
 
             if (responseCode == 200) {
-                JSONArray responseArray = Requester.getJSONArray(connection);
+                // FIXME? should this not disconnect?
+                // HTTPURLConnection#disconnect says:
+                // disconnect if other requests to the server
+                // are unlikely in the near future.
+                JSONArray responseArray = Requester.getJSONArray(connection, true);
                 int length = responseArray.length();
                 for (int i = 0; i < length; i++) {
                     JSONObject obj = (JSONObject) responseArray.get(i);
@@ -96,13 +100,13 @@ public class SBRequester {
                     SponsorBlockUtils.messageToToast = str("submit_failed_duplicate");
                     break;
                 case 403:
-                    SponsorBlockUtils.messageToToast = str("submit_failed_forbidden", Requester.parseErrorJson(connection));
+                    SponsorBlockUtils.messageToToast = str("submit_failed_forbidden", Requester.parseErrorJson(connection, true));
                     break;
                 case 429:
                     SponsorBlockUtils.messageToToast = str("submit_failed_rate_limit");
                     break;
                 case 400:
-                    SponsorBlockUtils.messageToToast = str("submit_failed_invalid", Requester.parseErrorJson(connection));
+                    SponsorBlockUtils.messageToToast = str("submit_failed_invalid", Requester.parseErrorJson(connection, true));
                     break;
                 default:
                     SponsorBlockUtils.messageToToast = str("submit_failed_unknown_error", responseCode, connection.getResponseMessage());
@@ -143,7 +147,7 @@ public class SBRequester {
                         SponsorBlockUtils.messageToToast = str("vote_succeeded");
                         break;
                     case 403:
-                        SponsorBlockUtils.messageToToast = str("vote_failed_forbidden", Requester.parseErrorJson(connection));
+                        SponsorBlockUtils.messageToToast = str("vote_failed_forbidden", Requester.parseErrorJson(connection, true));
                         break;
                     default:
                         SponsorBlockUtils.messageToToast = str("vote_failed_unknown_error", responseCode, connection.getResponseMessage());
@@ -220,6 +224,6 @@ public class SBRequester {
     }
 
     private static JSONObject getJSONObject(Route route, String... params) throws Exception {
-        return Requester.getJSONObject(getConnectionFromRoute(route, params));
+        return Requester.getJSONObject(getConnectionFromRoute(route, params), true);
     }
 }

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
@@ -46,11 +46,11 @@ public class SBRequester {
             runVipCheck();
 
             if (responseCode == 200) {
-                // FIXME? should this not disconnect?
+                // FIXME? should this use Requester#getJSONArray and not disconnect?
                 // HTTPURLConnection#disconnect says:
                 // disconnect if other requests to the server
                 // are unlikely in the near future.
-                JSONArray responseArray = Requester.getJSONArray(connection, true);
+                JSONArray responseArray = Requester.parseJSONArrayAndDisconnect(connection);
                 int length = responseArray.length();
                 for (int i = 0; i < length; i++) {
                     JSONObject obj = (JSONObject) responseArray.get(i);
@@ -100,13 +100,13 @@ public class SBRequester {
                     SponsorBlockUtils.messageToToast = str("submit_failed_duplicate");
                     break;
                 case 403:
-                    SponsorBlockUtils.messageToToast = str("submit_failed_forbidden", Requester.parseErrorJson(connection, true));
+                    SponsorBlockUtils.messageToToast = str("submit_failed_forbidden", Requester.parseErrorJsonAndDisconnect(connection));
                     break;
                 case 429:
                     SponsorBlockUtils.messageToToast = str("submit_failed_rate_limit");
                     break;
                 case 400:
-                    SponsorBlockUtils.messageToToast = str("submit_failed_invalid", Requester.parseErrorJson(connection, true));
+                    SponsorBlockUtils.messageToToast = str("submit_failed_invalid", Requester.parseErrorJsonAndDisconnect(connection));
                     break;
                 default:
                     SponsorBlockUtils.messageToToast = str("submit_failed_unknown_error", responseCode, connection.getResponseMessage());
@@ -147,7 +147,7 @@ public class SBRequester {
                         SponsorBlockUtils.messageToToast = str("vote_succeeded");
                         break;
                     case 403:
-                        SponsorBlockUtils.messageToToast = str("vote_failed_forbidden", Requester.parseErrorJson(connection, true));
+                        SponsorBlockUtils.messageToToast = str("vote_failed_forbidden", Requester.parseErrorJsonAndDisconnect(connection));
                         break;
                     default:
                         SponsorBlockUtils.messageToToast = str("vote_failed_unknown_error", responseCode, connection.getResponseMessage());
@@ -224,6 +224,6 @@ public class SBRequester {
     }
 
     private static JSONObject getJSONObject(Route route, String... params) throws Exception {
-        return Requester.getJSONObject(getConnectionFromRoute(route, params), true);
+        return Requester.parseJSONObjectAndDisconnect(getConnectionFromRoute(route, params));
     }
 }

--- a/app/src/main/java/app/revanced/integrations/utils/LogHelper.java
+++ b/app/src/main/java/app/revanced/integrations/utils/LogHelper.java
@@ -53,16 +53,18 @@ public class LogHelper {
      */
     public static void printDebug(LogMessage message) {
         if (SettingsEnum.DEBUG.getBoolean()) {
-            var log = new StringBuilder(message.buildMessageString());
+            var messageString = message.buildMessageString();
 
             if (SettingsEnum.DEBUG_STACKTRACE.getBoolean()) {
+                var builder = new StringBuilder(messageString);
                 var sw = new StringWriter();
                 new Throwable().printStackTrace(new PrintWriter(sw));
 
-                log.append(String.format("\n%s", sw));
+                builder.append(String.format("\n%s", sw));
+                messageString = builder.toString();
             }
 
-            Log.d("revanced: " + message.findOuterClassSimpleName(), log.toString());
+            Log.d("revanced: " + message.findOuterClassSimpleName(), messageString);
         }
     }
 

--- a/app/src/main/java/app/revanced/integrations/utils/ReVancedUtils.java
+++ b/app/src/main/java/app/revanced/integrations/utils/ReVancedUtils.java
@@ -125,8 +125,18 @@ public class ReVancedUtils {
         return context.getResources().getConfiguration().smallestScreenWidthDp >= 600;
     }
 
+    /**
+     * Automatically logs any exceptions the runnable throws
+     */
     public static void runOnMainThread(Runnable runnable) {
-        new Handler(Looper.getMainLooper()).post(runnable);
+        Runnable exceptLoggingRunnable = () -> {
+            try {
+                runnable.run();
+            } catch (Exception ex) {
+                LogHelper.printException(() -> "Exception on main thread from runnable: " + runnable.toString(), ex);
+            }
+        };
+        new Handler(Looper.getMainLooper()).post(exceptLoggingRunnable);
     }
 
     /**


### PR DESCRIPTION
I changed the background thread pool so all threads run at max priority.

This change seems to reduce the average time needed to load the video UI, as the RYD vote fetch now gets priority over other background threads (the fetch is blocking the UI, it definitely should get priority). 

Currently this thread pool is only used by RYD for the fetch votes calls.