### PR TITLE
refactor(youtube/general-ads-patch): remove unused names

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
@@ -14,11 +14,6 @@ public final class GeneralAdsPatch extends Filter {
             "comment_thread", // skip blocking anything in the comments
             "download_",
             "library_recent_shelf",
-            "menu",
-            "root",
-            "-count",
-            "-space",
-            "-button",
             "playlist_add_to_option_wrapper" // do not block on "add to playlist" flyout menu
     };
 


### PR DESCRIPTION
menu, root, count, space and button are child component names of comment_thread. There's no point in blocking them, because you can only block comment_thread.