### PR TITLE
refactor(youtube/general-ads-patch): added new names

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
@@ -11,7 +11,9 @@ public final class GeneralAdsPatch extends Filter {
     private final String[] IGNORE = {
             "home_video_with_context",
             "related_video_with_context",
+            "search_video_with_context",
             "comment_thread", // skip blocking anything in the comments
+            "|comment.", // skip blocking anything in the comments replies
             "download_",
             "library_recent_shelf",
             "playlist_add_to_option_wrapper" // do not block on "add to playlist" flyout menu

--- a/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
@@ -11,7 +11,6 @@ public final class GeneralAdsPatch extends Filter {
     private final String[] IGNORE = {
             "home_video_with_context",
             "related_video_with_context",
-            "search_video_with_context",
             "comment_thread", // skip blocking anything in the comments
             "|comment.", // skip blocking anything in the comments replies
             "download_",


### PR DESCRIPTION
"search_video_with_context" are accessible through the opening of the following components:

![Screenshot_20221218_224551](https://user-images.githubusercontent.com/120989892/208321226-1dbdd0fe-7391-4332-af39-5fb667f9fb5f.png)

Meanwhile the component "|comment." exists only on comments replies, in place of "comment_thread".