### PR TITLE
fix(youtube/general-ads-patch): improved ignore list

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
@@ -13,9 +13,7 @@ public final class GeneralAdsPatch extends Filter {
             "related_video_with_context",
             "comment_thread", // skip blocking anything in the comments
             "|comment.", // skip blocking anything in the comments replies
-            "download_",
             "library_recent_shelf",
-            "playlist_add_to_option_wrapper" // do not block on "add to playlist" flyout menu
     };
 
     private final BlockRule custom = new CustomBlockRule(


### PR DESCRIPTION
As I explained in a previous occasion, some of the current ignore list component names are totally useless. Today I tried to remove them from the list and are still visible.

This is the screenshot of the final result:

<img width="313" alt="Immagine 2022-12-30 123620" src="https://user-images.githubusercontent.com/120989892/210066530-6e9d27f9-11fc-449a-81fb-02baa71b377c.png">
