### PR TITLE
fix(youtube/return-youtube-dislike): use manufacturer specific span styles

### DIFF
--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -326,7 +326,8 @@ public class ReturnYouTubeDislike {
                 }
                 // shift everything up, to compensate for the vertical movement caused by the font change below
                 // each section needs it's own Relative span, otherwise alignment is wrong
-                addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
+                addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(segmentedLeftSeparatorVerticalShiftRatio));
+
                 addSpanStyling(likesSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
                 addSpanStyling(dislikeSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
@@ -352,6 +353,7 @@ public class ReturnYouTubeDislike {
 
     private static boolean segmentedValuesSet = false;
     private static float segmentedVerticalShiftRatio;
+    private static float segmentedLeftSeparatorVerticalShiftRatio;
     private static float segmentedLeftSeparatorFontRatio;
     private static float segmentedLeftSeparatorHorizontalScaleRatio;
 
@@ -380,7 +382,7 @@ public class ReturnYouTubeDislike {
                 configManufacturer = "Google";
                 configSdk = 33;
                 // tested on Android 10 thru 13, and works well for all
-                segmentedVerticalShiftRatio = -0.18f; // move separators and like/dislike up by 18%
+                segmentedLeftSeparatorVerticalShiftRatio = segmentedVerticalShiftRatio = -0.18f; // move separators and like/dislike up by 18%
                 segmentedLeftSeparatorFontRatio = 1.8f;  // increase left separator size by 80%
                 segmentedLeftSeparatorHorizontalScaleRatio = 0.65f; // horizontally compress left separator by 35%
                 break;
@@ -388,7 +390,7 @@ public class ReturnYouTubeDislike {
                 configManufacturer = "samsung";
                 configSdk = 33;
                 // tested on S22
-                segmentedVerticalShiftRatio = -0.19f;
+                segmentedLeftSeparatorVerticalShiftRatio = segmentedVerticalShiftRatio = -0.19f;
                 segmentedLeftSeparatorFontRatio = 1.5f;
                 segmentedLeftSeparatorHorizontalScaleRatio = 0.7f;
                 break;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -331,7 +331,7 @@ public class ReturnYouTubeDislike {
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
                 final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%
 
-                // shift the left separator up by a smaller amount, to visually align it after changing the size
+                // shift everything up, to compensate for the vertical movement caused by the font change below
                 addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(likesSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -345,7 +345,7 @@ public class ReturnYouTubeDislike {
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(dislikeSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
 
-                // important: must set font size after vertical offset (otherwise alignment gets off)
+                // important: must add size scaling after vertical offset (otherwise alignment gets off)
                 addSpanStyling(leftSeparatorSpan, new RelativeSizeSpan(leftSeparatorFontRatio));
                 addSpanStyling(leftSeparatorSpan, new ScaleXSpan(leftSeparatorHorizontalScaleRatio));
                 // middle separator does not need resizing

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -11,7 +11,6 @@ import android.text.SpannableStringBuilder;
 import android.text.TextPaint;
 import android.text.style.CharacterStyle;
 import android.text.style.ForegroundColorSpan;
-import android.text.style.MetricAffectingSpan;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.ScaleXSpan;
 import android.util.DisplayMetrics;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -321,7 +321,8 @@ public class ReturnYouTubeDislike {
                 // but it's good enough and still visually better than not doing this scaling/shifting
                 //
                 // important: any changes made here should be tested on a few different devices.
-                // Getting these values perfect on one device, may looks wrong on another device
+                // Getting these values perfect on one device, may looks wrong on another device.
+                // The goal is a happy compromise for all devices.
                 final float verticalShiftRatio = -0.15f; // shift up by 15%
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
                 final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -321,7 +321,7 @@ public class ReturnYouTubeDislike {
                 // but it's good enough and still visually better than not doing this scaling/shifting
                 //
                 // important: any changes made here should be tested on a few different devices.
-                // Getting these values perfect ons one device, may looks quite wrong on another device
+                // Getting these values perfect on one device, may looks wrong on another device
                 final float verticalShiftRatio = -0.15f; // shift up by 15%
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
                 final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -394,7 +394,7 @@ public class ReturnYouTubeDislike {
         //
         // In generally, a single configuration will give perfect layout for all devices
         // with that manufacture and version of Android.
-        // In general, fine tuning based on density and screen size is usually not needed.
+        // Fine tuning based on screen size and densityDpi is usually not needed.
         switch (deviceManufacturer) {
             default: // use Google layout by default
             case "Google":

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -301,7 +301,7 @@ public class ReturnYouTubeDislike {
                 CharacterStyle noAntiAliasingStyle = new CharacterStyle() {
                     @Override
                     public void updateDrawState(TextPaint tp) {
-                        tp.setAntiAlias(false); // draw without anti-alising, to give a sharper edge
+                        tp.setAntiAlias(false); // draw without anti-aliasing, to give a sharper edge
                     }
                 };
                 addSpanStyling(leftSeparatorSpan, noAntiAliasingStyle);

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -337,7 +337,7 @@ public class ReturnYouTubeDislike {
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(dislikeSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
 
-                // must set font size after vertical shift (otherwise alignment gets off)
+                // must set font size after vertical offset (otherwise alignment gets off)
                 addSpanStyling(leftSeparatorSpan, new RelativeSizeSpan(leftSeparatorFontRatio));
                 addSpanStyling(leftSeparatorSpan, new ScaleXSpan(leftSeparatorHorizontalStretchRatio));
                 // middle separator does not need resizing

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -309,8 +309,8 @@ public class ReturnYouTubeDislike {
 
                 Spannable dislikeSpan = newSpannableWithDislikes(oldSpannable, voteData);
 
-                // use a larger font size on the left separator, but this causes the entire span (including the like/dislike text)
-                // to move downward.  Use a custom span to adjust the span back upward, at a relative ratio
+                // When using a larger font size on the left separator, the entire span becomes shifted downward (including the like/dislike text)
+                // Use a custom span to move the span back up to roughly the correct location
                 class RelativeVerticalOffsetSpan extends CharacterStyle {
                     final float relativeVerticalShiftRatio;
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -292,12 +292,9 @@ public class ReturnYouTubeDislike {
                 String middleSegmentedSeparatorString = "  •  ";
                 Spannable leftSeparatorSpan = newSpanUsingStylingOfAnotherSpan(oldSpannable, leftSegmentedSeparatorString);
                 Spannable middleSeparatorSpan = newSpanUsingStylingOfAnotherSpan(oldSpannable, middleSegmentedSeparatorString);
-                // style the separator appearance to mimic the existing layout
                 final int separatorColor = ThemeHelper.isDarkTheme()
-                        // it might be possible to extract these colors from the litho layout
-                        // and put these colors in LithoThemePatch (but that would add a dependency for this RYD patch)
-                        ? 0xFF313131  // dark gray // FIXME: the stock separators have a slight transparency
-                        : 0xFFD9D9D9; // light gray // FIXME: need to find the exact transparency level, and use that here
+                        ? 0x37A0A0A0  // transparent dark gray
+                        : 0xFFD9D9D9; // light gray
                 addSpanStyling(leftSeparatorSpan, new ForegroundColorSpan(separatorColor));
                 addSpanStyling(middleSeparatorSpan, new ForegroundColorSpan(separatorColor));
                 CharacterStyle noAntiAliasingStyle = new CharacterStyle() {
@@ -328,6 +325,7 @@ public class ReturnYouTubeDislike {
                     }
                 }
                 // shift everything up, to compensate for the vertical movement caused by the font change below
+                // each section needs it's own Relative span, otherwise alignment is wrong
                 addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
                 addSpanStyling(likesSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(segmentedVerticalShiftRatio));
@@ -358,7 +356,7 @@ public class ReturnYouTubeDislike {
     private static float segmentedLeftSeparatorHorizontalScaleRatio;
 
     /**
-     * Set the size/position adjustment values, based on the device.
+     * Set the segmented adjustment values, based on the device.
      */
     private static void setSegmentedAdjustmentValues() {
         if (segmentedValuesSet) {
@@ -388,7 +386,7 @@ public class ReturnYouTubeDislike {
         // ie: If later adding Sony Android 12, then that configuration applies only to Sony Android 12.
         // For logging/documentation variables, use the values in the log output above.
         //
-        // IMPORTANT: configurations must be with the system font size default setting.
+        // IMPORTANT: configurations must be with the default system font size setting.
         // If you want to add font size specific configurations, then add multiple configurations based on scaledDensity.
         //
         // In generally, a single configuration will give perfect layout for all devices

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -301,7 +301,7 @@ public class ReturnYouTubeDislike {
                 CharacterStyle noAntiAliasingStyle = new CharacterStyle() {
                     @Override
                     public void updateDrawState(TextPaint tp) {
-                        tp.setAntiAlias(false); // draw without antialising, to give a sharper edge
+                        tp.setAntiAlias(false); // draw without anti-alising, to give a sharper edge
                     }
                 };
                 addSpanStyling(leftSeparatorSpan, noAntiAliasingStyle);

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -327,6 +327,9 @@ public class ReturnYouTubeDislike {
                 // Ratio values tested on Android 13, Samsung, Google and OnePlus branded phones, using screen densities of 300 to 560
                 // On other devices and fonts the left separator may be off vertically by a few pixels,
                 // but it's good enough and still visually better than not doing this scaling/shifting
+                //
+                // important: any changes made here should be tested on a few different devices
+                // getting these values perfect on one device, may looks quite wrong on another device
                 final float verticalShiftRatio = -0.15f; // shift up by 15%
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
                 final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -401,7 +401,7 @@ public class ReturnYouTubeDislike {
                 segmentedLeftSeparatorVerticalShiftRatio = -0.075f;
                 segmentedVerticalShiftRatio = -0.38f;
                 segmentedLeftSeparatorFontRatio = 1.87f;
-                segmentedLeftSeparatorHorizontalScaleRatio = 0.91f;
+                segmentedLeftSeparatorHorizontalScaleRatio = 0.50f;
                 break;
 
         }

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -255,7 +255,7 @@ public class ReturnYouTubeDislike {
             }
             replacementSpannable = newSpannableWithDislikes(oldSpannable, voteData);
         } else {
-            String leftSegmentedSeparatorString = ReVancedUtils.isRightToLeftTextLayout() ? "\u200F|   " : "|   ";
+            String leftSegmentedSeparatorString = ReVancedUtils.isRightToLeftTextLayout() ? "\u200F|  " : "|  ";
 
             if (oldLikesString.contains(leftSegmentedSeparatorString)) {
                 return false; // dislikes was previously added

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -255,7 +255,7 @@ public class ReturnYouTubeDislike {
             }
             replacementSpannable = newSpannableWithDislikes(oldSpannable, voteData);
         } else {
-            String leftSegmentedSeparatorString = ReVancedUtils.isRightToLeftTextLayout() ? "\u200F|  " : "|  ";
+            String leftSegmentedSeparatorString = ReVancedUtils.isRightToLeftTextLayout() ? "\u200F|   " : "|   ";
 
             if (oldLikesString.contains(leftSegmentedSeparatorString)) {
                 return false; // dislikes was previously added
@@ -294,26 +294,18 @@ public class ReturnYouTubeDislike {
                 Spannable middleSeparatorSpan = newSpanUsingStylingOfAnotherSpan(oldSpannable, middleSegmentedSeparatorString);
                 // style the separator appearance to mimic the existing layout
                 final int separatorColor = ThemeHelper.isDarkTheme()
-                        ? 0xFF414141  // dark gray
+                        ? 0xFF424242  // dark gray
                         : 0xFFD9D9D9; // light gray
                 addSpanStyling(leftSeparatorSpan, new ForegroundColorSpan(separatorColor));
                 addSpanStyling(middleSeparatorSpan, new ForegroundColorSpan(separatorColor));
-                MetricAffectingSpan separatorStyle = new MetricAffectingSpan() {
-                    final float separatorHorizontalCompression = 0.71f; // horizontally compress the separator and its spacing
-
-                    @Override
-                    public void updateMeasureState(TextPaint tp) {
-                        tp.setTextScaleX(separatorHorizontalCompression);
-                    }
-
+                CharacterStyle noAntiAliasingStyle = new CharacterStyle() {
                     @Override
                     public void updateDrawState(TextPaint tp) {
-                        tp.setTextScaleX(separatorHorizontalCompression);
-                        tp.setAntiAlias(false);
+                        tp.setAntiAlias(false); // draw without antialising, to give a sharper edge
                     }
                 };
-                addSpanStyling(leftSeparatorSpan, separatorStyle);
-                addSpanStyling(middleSeparatorSpan, separatorStyle);
+                addSpanStyling(leftSeparatorSpan, noAntiAliasingStyle);
+                addSpanStyling(middleSeparatorSpan, noAntiAliasingStyle);
 
                 Spannable dislikeSpan = newSpannableWithDislikes(oldSpannable, voteData);
 
@@ -335,20 +327,19 @@ public class ReturnYouTubeDislike {
                 // Ratio values tested on Android 13, Samsung, Google and OnePlus branded phones, using screen densities of 300 to 560
                 // On other devices and fonts the left separator may be vertically shifted by a few pixels,
                 // but it's good enough and still visually better than not doing this scaling/shifting
-                final float verticalShiftRatio = -0.38f; // shift up by 38%
-                final float verticalLeftSeparatorShiftRatio = -0.075f; // shift up by 8%
-                final float horizontalStretchRatio = 0.92f; // stretch narrower by 8%
-                final float leftSeparatorFontRatio = 1.87f;  // increase height by 87%
-
-                addSpanStyling(leftSeparatorSpan, new RelativeSizeSpan(leftSeparatorFontRatio));
-                addSpanStyling(leftSeparatorSpan, new ScaleXSpan(horizontalStretchRatio));
+                final float verticalShiftRatio = -0.15f; // shift up by 15%
+                final float leftSeparatorHorizontalStretchRatio = 0.65f; // compress horizontally by 35%
+                final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
 
                 // shift the left separator up by a smaller amount, to visually align it after changing the size
-                addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(verticalLeftSeparatorShiftRatio));
+                addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(likesSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(dislikeSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
 
+                // must set font size after vertical shift (otherwise alignment gets off)
+                addSpanStyling(leftSeparatorSpan, new RelativeSizeSpan(leftSeparatorFontRatio));
+                addSpanStyling(leftSeparatorSpan, new ScaleXSpan(leftSeparatorHorizontalStretchRatio));
                 // middle separator does not need resizing
 
                 // put everything together
@@ -364,6 +355,7 @@ public class ReturnYouTubeDislike {
         textRef.set(replacementSpannable);
         return true;
     }
+
 
     /**
      * Correctly handles any unicode numbers (such as Arabic numbers)

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -407,7 +407,7 @@ public class ReturnYouTubeDislike {
                 // actual adjustment values
                 segmentedVerticalShiftRatio = -0.18f; // move separators and like/dislike up by 18%
                 segmentedLeftSeparatorFontRatio = 1.8f;  // increase left separator size by 80%
-                segmentedLeftSeparatorHorizontalScaleRatio = 0.75f; // horizontally compress left separator by 25%
+                segmentedLeftSeparatorHorizontalScaleRatio = 0.65f; // horizontally compress left separator by 35%
                 break;
             case "samsung":
                 configManufacturer = "samsung";

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -309,8 +309,20 @@ public class ReturnYouTubeDislike {
 
                 Spannable dislikeSpan = newSpannableWithDislikes(oldSpannable, voteData);
 
-                // When using a larger font size on the left separator, the entire span becomes shifted downward (including the like/dislike text)
-                // Use a custom span to move the span back up to roughly the correct location
+                // Increase the size of the left separator, so it better matches the stock separator on the right.
+                // But when using a larger font, the entire span (including the like/dislike text) becomes shifted downward.
+                // To correct this, use additional spans to move the alignment back upward by a relative amount.
+                //
+                // The ratio values here were tested on Android 13,
+                // using Samsung, Google and OnePlus branded phones with screen densities of 300 to 560.
+                // On other devices and fonts the left separator may be off vertically by a few pixels,
+                // but it's good enough and still visually better than not doing this scaling/shifting
+                //
+                // important: any changes made here should be tested on a few different devices
+                // getting these values perfect on one device, may looks quite wrong on another device
+                final float verticalShiftRatio = -0.15f; // shift up by 15%
+                final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
+                final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%
                 class RelativeVerticalOffsetSpan extends CharacterStyle {
                     final float relativeVerticalShiftRatio;
 
@@ -323,16 +335,6 @@ public class ReturnYouTubeDislike {
                         tp.baselineShift -= (int) (relativeVerticalShiftRatio * tp.getFontMetrics().top);
                     }
                 }
-
-                // Ratio values tested on Android 13, Samsung, Google and OnePlus branded phones, using screen densities of 300 to 560
-                // On other devices and fonts the left separator may be off vertically by a few pixels,
-                // but it's good enough and still visually better than not doing this scaling/shifting
-                //
-                // important: any changes made here should be tested on a few different devices
-                // getting these values perfect on one device, may looks quite wrong on another device
-                final float verticalShiftRatio = -0.15f; // shift up by 15%
-                final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
-                final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%
 
                 // shift everything up, to compensate for the vertical movement caused by the font change below
                 addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -365,20 +365,7 @@ public class ReturnYouTubeDislike {
 
         String deviceManufacturer = Build.MANUFACTURER;
         final int deviceSdkVersion = Build.VERSION.SDK_INT;
-        DisplayMetrics metric = ReVancedUtils.getContext().getResources().getDisplayMetrics();
-        final float deviceScaledDensity = metric.scaledDensity;
-        final int deviceDensityDpi = metric.densityDpi;
-        final int deviceWidth = metric.widthPixels;
-        final int deviceHeight = metric.heightPixels;
-        LogHelper.printDebug(() -> "Device manufacturer: '" + deviceManufacturer + "' SDK: " + deviceSdkVersion
-                + " scaledDensity: " + deviceScaledDensity + " densityDpi: " + deviceDensityDpi
-                + " width: " + deviceWidth + " height: " + deviceHeight);
-
-        // device used to determine the configuration below
-        final String configManufacturer; // very important
-        final int configSdk; // important
-        final float configScaledDensityDpi; // important only if using non default system font size
-        final int configDensityDpi, configWidth, configHeight; // rarely important
+        LogHelper.printDebug(() -> "Device manufacturer: '" + deviceManufacturer + "' SDK: " + deviceSdkVersion);
 
         // If adding a configuration, then apply the new configuration to the
         // broadest number of devices while preserving existing settings.
@@ -387,22 +374,17 @@ public class ReturnYouTubeDislike {
         // For logging/documentation variables, use the values in the log output above.
         //
         // IMPORTANT: configurations must be with the default system font size setting.
-        // If you want to add font size specific configurations, then add multiple configurations based on scaledDensity.
         //
-        // In generally, a single configuration will give perfect layout for all devices
-        // with that manufacture and version of Android.
-        // Fine tuning based on screen size and densityDpi is usually not needed.
+        // In generally, a single configuration will give perfect layout for all devices of the same manufacturer
+        final String configManufacturer;
+        final int configSdk;
         switch (deviceManufacturer) {
             default: // use Google layout by default
             case "Google":
                 // logging and documentation
                 configManufacturer = "Google";
                 configSdk = 33;
-                configScaledDensityDpi = 2.75f;
-                configDensityDpi = 560;
-                configWidth = 1080;
-                configHeight = 2154;
-                // actual adjustment values
+                // tested on Android 10 thru 13, and works well for all
                 segmentedVerticalShiftRatio = -0.18f; // move separators and like/dislike up by 18%
                 segmentedLeftSeparatorFontRatio = 1.8f;  // increase left separator size by 80%
                 segmentedLeftSeparatorHorizontalScaleRatio = 0.65f; // horizontally compress left separator by 35%
@@ -410,18 +392,14 @@ public class ReturnYouTubeDislike {
             case "samsung":
                 configManufacturer = "samsung";
                 configSdk = 33;
-                configScaledDensityDpi = 3.0f;
-                configDensityDpi = 480;
-                configWidth = 1080;
-                configHeight = 2124;
+                // tested on S22
                 segmentedVerticalShiftRatio = -0.19f;
                 segmentedLeftSeparatorFontRatio = 1.5f;
                 segmentedLeftSeparatorHorizontalScaleRatio = 0.7f;
                 break;
         }
 
-        LogHelper.printDebug(() -> "Using layout adjustments based on manufacturer: '" + configManufacturer + "' SDK: " + configSdk
-                + " scaledDensity: " + configScaledDensityDpi + " densityDpi: " + configDensityDpi + " width: " + configWidth + " height: " + configHeight);
+        LogHelper.printDebug(() -> "Using layout adjustments based on manufacturer: '" + configManufacturer + "' SDK: " + configSdk);
         segmentedValuesSet = true;
     }
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -367,11 +367,6 @@ public class ReturnYouTubeDislike {
         final int deviceSdkVersion = Build.VERSION.SDK_INT;
         LogHelper.printDebug(() -> "Device manufacturer: '" + deviceManufacturer + "' SDK: " + deviceSdkVersion);
 
-        // If adding a configuration, then apply the new configuration to the
-        // broadest number of devices while preserving existing settings.
-        // ie: A new configuration for a Sony Android 13 phone should apply to all Sony phones.
-        // ie: If later adding Sony Android 12, then that configuration applies only to Sony Android 12.
-        // For logging/documentation variables, use the values in the log output above.
         //
         // IMPORTANT: configurations must be with the default system font size setting.
         //

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -394,6 +394,16 @@ public class ReturnYouTubeDislike {
                 segmentedLeftSeparatorFontRatio = 1.5f;
                 segmentedLeftSeparatorHorizontalScaleRatio = 0.7f;
                 break;
+            case "OnePlus":
+                configManufacturer = "oneplus";
+                configSdk = 33;
+                // tested on OnePlus 8 Pro
+                segmentedLeftSeparatorVerticalShiftRatio = -0.075f;
+                segmentedVerticalShiftRatio = -0.38f;
+                segmentedLeftSeparatorFontRatio = 1.87f;
+                segmentedLeftSeparatorHorizontalScaleRatio = 0.91f;
+                break;
+
         }
 
         LogHelper.printDebug(() -> "Using layout adjustments based on manufacturer: '" + configManufacturer + "' SDK: " + configSdk);

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -297,8 +297,8 @@ public class ReturnYouTubeDislike {
                 final int separatorColor = ThemeHelper.isDarkTheme()
                         // it might be possible to extract these colors from the litho layout
                         // and put these colors in LithoThemePatch (but that would add a dependency for this RYD patch)
-                        ? 0xFF424242  // dark gray
-                        : 0xFFD9D9D9; // light gray
+                        ? 0xFF313131  // dark gray // FIXME: the stock separators have a slight transparency
+                        : 0xFFD9D9D9; // light gray // FIXME: need to find the exact transparency level, and use that here
                 addSpanStyling(leftSeparatorSpan, new ForegroundColorSpan(separatorColor));
                 addSpanStyling(middleSeparatorSpan, new ForegroundColorSpan(separatorColor));
                 CharacterStyle noAntiAliasingStyle = new CharacterStyle() {

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -406,7 +406,7 @@ public class ReturnYouTubeDislike {
                 configWidth = 1080;
                 configHeight = 2154;
                 // actual adjustment values
-                segmentedVerticalShiftRatio = -0.18f; // move separator and like/dislike up by 18%
+                segmentedVerticalShiftRatio = -0.18f; // move separators and like/dislike up by 18%
                 segmentedLeftSeparatorFontRatio = 1.8f;  // increase left separator size by 80%
                 segmentedLeftSeparatorHorizontalScaleRatio = 0.75f; // horizontally compress left separator by 25%
                 break;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -294,6 +294,8 @@ public class ReturnYouTubeDislike {
                 Spannable middleSeparatorSpan = newSpanUsingStylingOfAnotherSpan(oldSpannable, middleSegmentedSeparatorString);
                 // style the separator appearance to mimic the existing layout
                 final int separatorColor = ThemeHelper.isDarkTheme()
+                        // it might be possible to extract these colors from the litho layout
+                        // and put these colors in LithoThemePatch (but that would add a dependency for this RYD patch
                         ? 0xFF424242  // dark gray
                         : 0xFFD9D9D9; // light gray
                 addSpanStyling(leftSeparatorSpan, new ForegroundColorSpan(separatorColor));

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -328,7 +328,7 @@ public class ReturnYouTubeDislike {
                 // On other devices and fonts the left separator may be vertically shifted by a few pixels,
                 // but it's good enough and still visually better than not doing this scaling/shifting
                 final float verticalShiftRatio = -0.15f; // shift up by 15%
-                final float leftSeparatorHorizontalStretchRatio = 0.65f; // compress horizontally by 35%
+                final float leftSeparatorHorizontalStretchRatio = 0.6f; // compress horizontally by 40%
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
 
                 // shift the left separator up by a smaller amount, to visually align it after changing the size

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -325,11 +325,11 @@ public class ReturnYouTubeDislike {
                 }
 
                 // Ratio values tested on Android 13, Samsung, Google and OnePlus branded phones, using screen densities of 300 to 560
-                // On other devices and fonts the left separator may be vertically shifted by a few pixels,
+                // On other devices and fonts the left separator may be off vertically by a few pixels,
                 // but it's good enough and still visually better than not doing this scaling/shifting
                 final float verticalShiftRatio = -0.15f; // shift up by 15%
-                final float leftSeparatorHorizontalStretchRatio = 0.6f; // compress horizontally by 40%
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
+                final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%
 
                 // shift the left separator up by a smaller amount, to visually align it after changing the size
                 addSpanStyling(leftSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
@@ -337,9 +337,9 @@ public class ReturnYouTubeDislike {
                 addSpanStyling(middleSeparatorSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
                 addSpanStyling(dislikeSpan, new RelativeVerticalOffsetSpan(verticalShiftRatio));
 
-                // must set font size after vertical offset (otherwise alignment gets off)
+                // important: must set font size after vertical offset (otherwise alignment gets off)
                 addSpanStyling(leftSeparatorSpan, new RelativeSizeSpan(leftSeparatorFontRatio));
-                addSpanStyling(leftSeparatorSpan, new ScaleXSpan(leftSeparatorHorizontalStretchRatio));
+                addSpanStyling(leftSeparatorSpan, new ScaleXSpan(leftSeparatorHorizontalScaleRatio));
                 // middle separator does not need resizing
 
                 // put everything together

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -371,10 +371,10 @@ public class ReturnYouTubeDislike {
         DisplayMetrics metric = ReVancedUtils.getContext().getResources().getDisplayMetrics();
         final float deviceScaledDensity = metric.scaledDensity;
         final int deviceDensityDpi = metric.densityDpi;
-        final int deviceHeight = metric.heightPixels;
         final int deviceWidth = metric.widthPixels;
+        final int deviceHeight = metric.heightPixels;
         LogHelper.printDebug(() -> "Device manufacturer: '" + deviceManufacturer + "' SDK: " + deviceSdkVersion
-                + " scaledDensity: " + deviceScaledDensity + " densityDpi:" + deviceDensityDpi
+                + " scaledDensity: " + deviceScaledDensity + " densityDpi: " + deviceDensityDpi
                 + " width: " + deviceWidth + " height: " + deviceHeight);
 
         // device used to determine the configuration below

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -378,14 +378,10 @@ public class ReturnYouTubeDislike {
                 + " width: " + deviceWidth + " height: " + deviceHeight);
 
         // device used to determine the configuration below
-        final String manufacturer; // very important
-        final int sdk; // important
-        final float scaledDensityDpi; // important only if using non default system font size
-        final int densityDpi, width, height; // rarely important
-        // configuration based on the specific device above
-        final float verticalShiftRatio;
-        final float leftSeparatorFontRatio;
-        final float leftSeparatorHorizontalScaleRatio;
+        final String configManufacturer; // very important
+        final int configSdk; // important
+        final float configScaledDensityDpi; // important only if using non default system font size
+        final int configDensityDpi, configWidth, configHeight; // rarely important
 
         // If adding a configuration, then apply the new configuration to the
         // broadest number of devices while preserving existing settings.
@@ -403,36 +399,32 @@ public class ReturnYouTubeDislike {
             default: // use Google layout by default
             case "Google":
                 // logging and documentation
-                manufacturer = "Google";
-                sdk = 33;
-                scaledDensityDpi = 2.75f;
-                densityDpi = 560;
-                width = 1080;
-                height = 2154;
+                configManufacturer = "Google";
+                configSdk = 33;
+                configScaledDensityDpi = 2.75f;
+                configDensityDpi = 560;
+                configWidth = 1080;
+                configHeight = 2154;
                 // actual adjustment values
-                verticalShiftRatio = -0.18f; // move separator and like/dislike up by 18%
-                leftSeparatorFontRatio = 1.8f;  // increase left separator size by 80%
-                leftSeparatorHorizontalScaleRatio = 0.75f; // horizontally compress left separator by 25%
+                segmentedVerticalShiftRatio = -0.18f; // move separator and like/dislike up by 18%
+                segmentedLeftSeparatorFontRatio = 1.8f;  // increase left separator size by 80%
+                segmentedLeftSeparatorHorizontalScaleRatio = 0.75f; // horizontally compress left separator by 25%
                 break;
             case "samsung":
-                manufacturer = "samsung";
-                sdk = 33;
-                scaledDensityDpi = 3.0f;
-                densityDpi = 480;
-                width = 1080;
-                height = 2124;
-                verticalShiftRatio = -0.19f;
-                leftSeparatorFontRatio = 1.5f;
-                leftSeparatorHorizontalScaleRatio = 0.7f;
+                configManufacturer = "samsung";
+                configSdk = 33;
+                configScaledDensityDpi = 3.0f;
+                configDensityDpi = 480;
+                configWidth = 1080;
+                configHeight = 2124;
+                segmentedVerticalShiftRatio = -0.19f;
+                segmentedLeftSeparatorFontRatio = 1.5f;
+                segmentedLeftSeparatorHorizontalScaleRatio = 0.7f;
                 break;
         }
 
-        LogHelper.printDebug(() -> "Using layout adjustments based on manufacturer: '" + manufacturer + "' SDK: " + sdk
-                + " scaledDensity: " + scaledDensityDpi + " densityDpi: " + densityDpi + " width: " + width + " height: " + height);
-
-        segmentedVerticalShiftRatio = verticalShiftRatio;
-        segmentedLeftSeparatorFontRatio = leftSeparatorFontRatio;
-        segmentedLeftSeparatorHorizontalScaleRatio = leftSeparatorHorizontalScaleRatio;
+        LogHelper.printDebug(() -> "Using layout adjustments based on manufacturer: '" + configManufacturer + "' SDK: " + configSdk
+                + " scaledDensity: " + configScaledDensityDpi + " densityDpi: " + configDensityDpi + " width: " + configWidth + " height: " + configHeight);
         segmentedValuesSet = true;
     }
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -318,8 +318,8 @@ public class ReturnYouTubeDislike {
                 // On other devices and fonts the left separator may be off vertically by a few pixels,
                 // but it's good enough and still visually better than not doing this scaling/shifting
                 //
-                // important: any changes made here should be tested on a few different devices
-                // getting these values perfect on one device, may looks quite wrong on another device
+                // important: any changes made here should be tested on a few different devices.
+                // Getting these values perfect ons one device, may looks quite wrong on another device
                 final float verticalShiftRatio = -0.15f; // shift up by 15%
                 final float leftSeparatorFontRatio = 1.6f;  // increase height by 60%
                 final float leftSeparatorHorizontalScaleRatio = 0.6f; // compress horizontally by 40%

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -295,7 +295,7 @@ public class ReturnYouTubeDislike {
                 // style the separator appearance to mimic the existing layout
                 final int separatorColor = ThemeHelper.isDarkTheme()
                         // it might be possible to extract these colors from the litho layout
-                        // and put these colors in LithoThemePatch (but that would add a dependency for this RYD patch
+                        // and put these colors in LithoThemePatch (but that would add a dependency for this RYD patch)
                         ? 0xFF424242  // dark gray
                         : 0xFFD9D9D9; // light gray
                 addSpanStyling(leftSeparatorSpan, new ForegroundColorSpan(separatorColor));


### PR DESCRIPTION
The OnePlus changes pushed my Samsung and Google phones out of wack.

No set of ratios will be perfect for all devices, all we can get is good enough for most devices

Can you see if these changes looks ok on your device?

Here's what it this PR looks like on my end:

Google Pixel (with this PR):
<img alt="gogle pixel" src="https://user-images.githubusercontent.com/118716522/210128190-4168e564-31b9-4bf9-8be7-c8c8155dccd9.png">


Samsung (with this PR):
![samsung](https://user-images.githubusercontent.com/118716522/210128192-b8b75b9b-b0eb-4cd4-8ebe-9d906e86d785.png)

