### PR TITLE
build: fix release-package-name's version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
       with:
         node-version: "latest"
         cache: 'npm'
-    - name: Build with Gradle
-      run: ./gradlew build --no-daemon
     - name: Setup semantic-release
       run: npm install semantic-release @saithodev/semantic-release-backmerge @semantic-release/git @semantic-release/changelog gradle-semantic-release-plugin -D
     - name: Release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,3 +51,5 @@ dependencies {
     compileOnly("com.squareup.okhttp3:okhttp:4.10.0")
     compileOnly("com.squareup.retrofit2:retrofit:2.9.0")
 }
+
+tasks.register("publish") { dependsOn("build") }


### PR DESCRIPTION
This PR fixes mismatched released package name versions.

Specifically, replace "./gradlew build" with the gradle-semantic-release-plugin method.
"./gradlew build" task is executed after automatic rewriting of gradle.properties's version.