### PR TITLE
RYD: better color match of existing dark mode separator color

### DIFF
--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -292,7 +292,7 @@ public class ReturnYouTubeDislike {
                 Spannable leftSeparatorSpan = newSpanUsingStylingOfAnotherSpan(oldSpannable, leftSegmentedSeparatorString);
                 Spannable middleSeparatorSpan = newSpanUsingStylingOfAnotherSpan(oldSpannable, middleSegmentedSeparatorString);
                 final int separatorColor = ThemeHelper.isDarkTheme()
-                        ? 0x37A0A0A0  // transparent dark gray
+                        ? 0x29AAAAAA  // transparent dark gray
                         : 0xFFD9D9D9; // light gray
                 addSpanStyling(leftSeparatorSpan, new ForegroundColorSpan(separatorColor));
                 addSpanStyling(middleSeparatorSpan, new ForegroundColorSpan(separatorColor));


### PR DESCRIPTION
I got a better match of the separator color.  This is about the best it's going to get.

![black background video](https://user-images.githubusercontent.com/118716522/211167194-8094bd2c-39da-4238-8c85-695db2f06726.png)
![red background video](https://user-images.githubusercontent.com/118716522/211167280-2f092a0b-525c-43c6-b511-840e9c4f9b38.png)
![green background video](https://user-images.githubusercontent.com/118716522/211167200-f0edba30-5ef8-4ec4-b045-337eebbef815.png)
