### PR TITLE
fix: microg check not showing toast

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
+++ b/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
@@ -26,6 +26,7 @@ public class MicroGSupport {
             Toast.makeText(context, str("microg_not_installed_warning"), Toast.LENGTH_LONG).show();
 
             var intent = new Intent(Intent.ACTION_VIEW);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setData(Uri.parse(VANCED_MICROG_DOWNLOAD_LINK));
             context.startActivity(intent);
         }


### PR DESCRIPTION
Fixes the Vanced MicroG check not showing a toast to make the user install Vanced MicroG

**Note: It still does not show a toast but it opens the download page for Vanced MicroG before crashing with this error:**

```
AndroidRuntime: FATAL EXCEPTION: yt-critical Thread #0
AndroidRuntime: Process: app.revanced.android.youtube, PID: 7179
AndroidRuntime: java.lang.SecurityException: Failed to find provider com.mgoogle.android.gsf.gservices for user 0; expected to find a valid ContentProvider for this authority
```