### PR TITLE
fix(YouTube) Gracefully close app if MicroG is missing or not running

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
+++ b/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
@@ -27,9 +27,6 @@ public class MicroGSupport {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.setData(Uri.parse(uriString));
         context.startActivity(intent);
-
-        // if we don't exit now, the app will immediately crash and the phone OS may complain the app is broken
-        System.exit(0); // force app to close gracefully
     }
 
     public static void checkAvailability() {
@@ -40,7 +37,9 @@ public class MicroGSupport {
         } catch (PackageManager.NameNotFoundException exception) {
             LogHelper.printException(() -> ("Vanced MicroG was not found"), exception);
             startIntent(context, VANCED_MICROG_DOWNLOAD_LINK, str("microg_not_installed_warning"));
-            return;
+
+            // if we don't exit now, the app will immediately crash and the phone OS may complain the app is broken
+            System.exit(0); // force app to close gracefully
         }
 
         try (var client = context.getContentResolver().acquireContentProviderClient(VANCED_MICROG_PROVIDER)) {

--- a/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
+++ b/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
@@ -38,8 +38,8 @@ public class MicroGSupport {
             LogHelper.printException(() -> ("Vanced MicroG was not found"), exception);
             startIntent(context, VANCED_MICROG_DOWNLOAD_LINK, str("microg_not_installed_warning"));
 
-            // if we don't exit now, the app will immediately crash and the phone OS may complain the app is broken
-            System.exit(0); // force app to close gracefully
+            // Gracefully exit the app, so it does not crash.
+            System.exit(0);
         }
 
         try (var client = context.getContentResolver().acquireContentProviderClient(VANCED_MICROG_PROVIDER)) {

--- a/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
+++ b/app/src/main/java/app/revanced/integrations/patches/MicroGSupport.java
@@ -27,6 +27,9 @@ public class MicroGSupport {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.setData(Uri.parse(uriString));
         context.startActivity(intent);
+
+        // if we don't exit now, the app will immediately crash and the phone OS may complain the app is broken
+        System.exit(0); // force app to close gracefully
     }
 
     public static void checkAvailability() {
@@ -37,6 +40,7 @@ public class MicroGSupport {
         } catch (PackageManager.NameNotFoundException exception) {
             LogHelper.printException(() -> ("Vanced MicroG was not found"), exception);
             startIntent(context, VANCED_MICROG_DOWNLOAD_LINK, str("microg_not_installed_warning"));
+            return;
         }
 
         try (var client = context.getContentResolver().acquireContentProviderClient(VANCED_MICROG_PROVIDER)) {


### PR DESCRIPTION
Minor adjustment, so the app gracefully closes instead of crashing.

If the app is allowed to crash, then on Samsung devices it gives 'recommendations' to put the app to sleep or uninstall. 

These changes are verified working as expected.
