### PR TITLE
fix(YouTube/Sponsorblock) Fix import json settings.  Fix default userid showing as empty.  Fix skip segment toast not working.

### DIFF
--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -366,9 +366,8 @@ public enum SettingsEnum {
         value = newValue;
     }
 
-    // FIXME?  why does this return a primitive, when the other methods return objects?  Should this return an Integer?
     public int getInt() {
-        return (int) value;
+        return (Integer) value;
     }
 
     public String getString() {
@@ -379,11 +378,11 @@ public enum SettingsEnum {
         return (Boolean) value;
     }
 
-    public Long getLong() {
+    public long getLong() {
         return (Long) value;
     }
 
-    public Float getFloat() {
+    public float getFloat() {
         return (Float) value;
     }
 

--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -366,6 +366,7 @@ public enum SettingsEnum {
         value = newValue;
     }
 
+    // FIXME?  why does this return a primitive, when the other methods return objects?  Should this return an Integer?
     public int getInt() {
         return (int) value;
     }

--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -366,16 +366,12 @@ public enum SettingsEnum {
         value = newValue;
     }
 
-    public int getInt() {
-        return (Integer) value;
-    }
-
-    public String getString() {
-        return (String) value;
-    }
-
     public boolean getBoolean() {
         return (Boolean) value;
+    }
+
+    public int getInt() {
+        return (Integer) value;
     }
 
     public long getLong() {
@@ -384,6 +380,10 @@ public enum SettingsEnum {
 
     public float getFloat() {
         return (Float) value;
+    }
+
+    public String getString() {
+        return (String) value;
     }
 
     public Object getDefaultValue() {

--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -145,8 +145,7 @@ public enum SettingsEnum {
     SB_IS_VIP("sb-is-vip", false, SharedPrefHelper.SharedPrefNames.SPONSOR_BLOCK, ReturnType.BOOLEAN),
     SB_LAST_VIP_CHECK("sb-last-vip-check", 0L, SharedPrefHelper.SharedPrefNames.SPONSOR_BLOCK, ReturnType.LONG),
     SB_SHOW_BROWSER_BUTTON("sb-browser-button", false, SharedPrefHelper.SharedPrefNames.SPONSOR_BLOCK, ReturnType.BOOLEAN),
-    SB_API_URL("sb-api-url", "https://sponsor.ajay.app/api/", SharedPrefHelper.SharedPrefNames.SPONSOR_BLOCK, ReturnType.STRING),
-
+    SB_API_URL("sb-api-host-url", "https://sponsor.ajay.app", SharedPrefHelper.SharedPrefNames.SPONSOR_BLOCK, ReturnType.STRING),
 
     //
     // old deprecated settings, kept around to migrate user settings on existing installations

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/ReturnYouTubeDislikeSettingsFragment.java
@@ -62,8 +62,6 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
         setPreferenceScreen(preferenceScreen);
 
         enabledPreference = new SwitchPreference(context);
-        enabledPreference.setKey(SettingsEnum.RYD_ENABLED.getPath());
-        enabledPreference.setDefaultValue(SettingsEnum.RYD_ENABLED.getDefaultValue());
         enabledPreference.setChecked(SettingsEnum.RYD_ENABLED.getBoolean());
         enabledPreference.setTitle(str("revanced_ryd_enable_title"));
         enabledPreference.setOnPreferenceChangeListener((pref, newValue) -> {
@@ -77,8 +75,6 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
         preferenceScreen.addPreference(enabledPreference);
 
         percentagePreference = new SwitchPreference(context);
-        percentagePreference.setKey(SettingsEnum.RYD_SHOW_DISLIKE_PERCENTAGE.getPath());
-        percentagePreference.setDefaultValue(SettingsEnum.RYD_SHOW_DISLIKE_PERCENTAGE.getDefaultValue());
         percentagePreference.setChecked(SettingsEnum.RYD_SHOW_DISLIKE_PERCENTAGE.getBoolean());
         percentagePreference.setTitle(str("revanced_ryd_dislike_percentage_title"));
         percentagePreference.setOnPreferenceChangeListener((pref, newValue) -> {
@@ -90,8 +86,6 @@ public class ReturnYouTubeDislikeSettingsFragment extends PreferenceFragment {
         preferenceScreen.addPreference(percentagePreference);
 
         compactLayoutPreference = new SwitchPreference(context);
-        compactLayoutPreference.setKey(SettingsEnum.RYD_USE_COMPACT_LAYOUT.getPath());
-        compactLayoutPreference.setDefaultValue(SettingsEnum.RYD_USE_COMPACT_LAYOUT.getDefaultValue());
         compactLayoutPreference.setChecked(SettingsEnum.RYD_USE_COMPACT_LAYOUT.getBoolean());
         compactLayoutPreference.setTitle(str("revanced_ryd_compact_layout_title"));
         compactLayoutPreference.setOnPreferenceChangeListener((pref, newValue) -> {

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/SponsorBlockSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/SponsorBlockSettingsFragment.java
@@ -233,11 +233,14 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
         }
 
         {
-            Preference preference = new SwitchPreference(context);
+            SwitchPreference preference = new SwitchPreference(context);
             preference.setTitle(str("general_skiptoast"));
             preference.setSummary(str("general_skiptoast_sum"));
-            preference.setKey(SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.getPath());
-            preference.setDefaultValue(SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.getDefaultValue());
+            preference.setChecked(SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.getBoolean());
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.saveValue(newValue);
+                return true;
+            });
             preference.setOnPreferenceClickListener(preference12 -> {
                 Toast.makeText(preference12.getContext(), str("skipped_sponsor"), Toast.LENGTH_SHORT).show();
                 return false;
@@ -247,21 +250,28 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
         }
 
         {
-            Preference preference = new SwitchPreference(context);
+            SwitchPreference preference = new SwitchPreference(context);
             preference.setTitle(str("general_skipcount"));
             preference.setSummary(str("general_skipcount_sum"));
-            preference.setKey(SettingsEnum.SB_COUNT_SKIPS.getPath());
-            preference.setDefaultValue(SettingsEnum.SB_COUNT_SKIPS.getDefaultValue());
+            preference.setChecked(SettingsEnum.SB_COUNT_SKIPS.getBoolean());
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                SettingsEnum.SB_COUNT_SKIPS.saveValue(newValue);
+                return true;
+            });
             preferencesToDisableWhenSBDisabled.add(preference);
             screen.addPreference(preference);
         }
 
         {
-            Preference preference = new SwitchPreference(context);
+            SwitchPreference preference = new SwitchPreference(context);
             preference.setTitle(str("general_time_without_sb"));
             preference.setSummary(str("general_time_without_sb_sum"));
-            preference.setKey(SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.getPath());
-            preference.setDefaultValue(SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.getDefaultValue());
+            preference.setChecked(SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.getBoolean());
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.saveValue(newValue);
+                return true;
+            });
+
             preferencesToDisableWhenSBDisabled.add(preference);
             screen.addPreference(preference);
         }
@@ -271,8 +281,11 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
             preference.getEditText().setInputType(InputType.TYPE_CLASS_NUMBER);
             preference.setTitle(str("general_adjusting"));
             preference.setSummary(str("general_adjusting_sum"));
-            preference.setKey(SettingsEnum.SB_ADJUST_NEW_SEGMENT_STEP.getPath());
-            preference.setDefaultValue(SettingsEnum.SB_ADJUST_NEW_SEGMENT_STEP.getDefaultValue() + "");
+            preference.setText(String.valueOf(SettingsEnum.SB_ADJUST_NEW_SEGMENT_STEP.getInt()));
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                SettingsEnum.SB_ADJUST_NEW_SEGMENT_STEP.saveValue(Integer.valueOf(newValue.toString()));
+                return true;
+            });
             screen.addPreference(preference);
             preferencesToDisableWhenSBDisabled.add(preference);
         }
@@ -282,18 +295,25 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
             preference.getEditText().setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
             preference.setTitle(str("general_min_duration"));
             preference.setSummary(str("general_min_duration_sum"));
-            preference.setKey(SettingsEnum.SB_MIN_DURATION.getPath());
-            preference.setDefaultValue(SettingsEnum.SB_MIN_DURATION.getDefaultValue() + "");
+            preference.setText(String.valueOf(SettingsEnum.SB_MIN_DURATION.getFloat()));
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                SettingsEnum.SB_MIN_DURATION.saveValue(Float.valueOf(newValue.toString()));
+                return true;
+            });
             screen.addPreference(preference);
             preferencesToDisableWhenSBDisabled.add(preference);
         }
 
         {
-            Preference preference = new EditTextPreference(context);
+            EditTextPreference preference = new EditTextPreference(context);
             preference.setTitle(str("general_uuid"));
             preference.setSummary(str("general_uuid_sum"));
-            preference.setKey(SettingsEnum.SB_UUID.getPath());
-            preference.setDefaultValue(SettingsEnum.SB_UUID.getDefaultValue() + "");
+            preference.setText(SettingsEnum.SB_UUID.getString());
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                SettingsEnum.SB_UUID.saveValue(newValue.toString());
+                return true;
+            });
+
             screen.addPreference(preference);
             preferencesToDisableWhenSBDisabled.add(preference);
         }

--- a/app/src/main/java/app/revanced/integrations/settingsmenu/SponsorBlockSettingsFragment.java
+++ b/app/src/main/java/app/revanced/integrations/settingsmenu/SponsorBlockSettingsFragment.java
@@ -171,6 +171,7 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
         screen.addPreference(colorPreference);
         colorPreference.setTitle(str("color_change"));
         colorPreference.setSummary(str("color_change_sum"));
+        colorPreference.setSelectable(false);
         preferencesToDisableWhenSBDisabled.add(colorPreference);
     }
 
@@ -184,6 +185,7 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
             Preference preference = new Preference(context);
             category.addPreference(preference);
             preference.setTitle(str("stats_loading"));
+            preference.setSelectable(false);
 
             SBRequester.retrieveUserStats(category, preference);
         }
@@ -211,6 +213,7 @@ public class SponsorBlockSettingsFragment extends PreferenceFragment implements 
             Preference preference = new Preference(context);
             screen.addPreference(preference);
             preference.setTitle(str("about_madeby"));
+            preference.setSelectable(false);
         }
 
     }

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/PlayerController.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/PlayerController.java
@@ -174,14 +174,13 @@ public class PlayerController {
                 SettingsEnum.SB_SKIPPED_SEGMENTS_TIME.saveValue(newSkippedTime);
             }
         }
-        new Thread(() -> {
-            if (SettingsEnum.SB_COUNT_SKIPS.getBoolean() &&
-                    segment.category != SponsorBlockSettings.SegmentInfo.UNSUBMITTED &&
-                    millis - segment.start < 2000) {
-                // Only skips from the start should count as a view
+        if (SettingsEnum.SB_COUNT_SKIPS.getBoolean()
+                && segment.category != SponsorBlockSettings.SegmentInfo.UNSUBMITTED
+                && millis - segment.start < 2000) { // Only skips from the start should count as a view
+            ReVancedUtils.runOnBackgroundThread(() -> {
                 SBRequester.sendViewCountRequest(segment);
-            }
-        }).start();
+            });
+        }
     }
 
     public static void setHighPrecisionVideoTime(final long millis) {

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockSettings.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockSettings.java
@@ -83,7 +83,7 @@ public class SponsorBlockSettings {
             sponsorBlockUrlCategories = "[%22" + TextUtils.join("%22,%22", enabledCategories) + "%22]";
 
         String uuid = SettingsEnum.SB_UUID.getString();
-        if (uuid == null) {
+        if (uuid == null || uuid.length() == 0) {
             uuid = (UUID.randomUUID().toString() +
                     UUID.randomUUID().toString() +
                     UUID.randomUUID().toString())

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
@@ -541,12 +541,12 @@ public abstract class SponsorBlockUtils {
                 editor.putString(category.key, behaviour.key);
             }
 
+            SettingsEnum.SB_UUID.saveValue(settingsJson.getString("userID"));
+            SettingsEnum.SB_IS_VIP.saveValue(settingsJson.getBoolean("isVip"));
             SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.saveValue(!settingsJson.getBoolean("dontShowNotice"));
             SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.saveValue(settingsJson.getBoolean("showTimeWithSkips"));
-            SettingsEnum.SB_COUNT_SKIPS.saveValue(settingsJson.getBoolean("trackViewCount"));
-            SettingsEnum.SB_IS_VIP.saveValue(settingsJson.getBoolean("isVip"));
             SettingsEnum.SB_MIN_DURATION.saveValue(Float.valueOf(settingsJson.getString("minDuration")));
-            SettingsEnum.SB_UUID.saveValue(settingsJson.getString("userID"));
+            SettingsEnum.SB_COUNT_SKIPS.saveValue(settingsJson.getBoolean("trackViewCount"));
 
             String serverAddress = settingsJson.getString("serverAddress");
             if (serverAddress.equalsIgnoreCase("https://sponsor.ajay.app")) {
@@ -583,15 +583,15 @@ public abstract class SponsorBlockUtils {
                     categorySelectionsArray.put(behaviorObject);
                 }
             }
+            json.put("userID", SettingsEnum.SB_UUID.getString());
+            json.put("isVip", SettingsEnum.SB_IS_VIP.getBoolean());
+            json.put("serverAddress", SettingsEnum.SB_API_URL.getString());
             json.put("dontShowNotice", !SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.getBoolean());
-            json.put("barTypes", barTypesObject);
             json.put("showTimeWithSkips", SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.getBoolean());
             json.put("minDuration", SettingsEnum.SB_MIN_DURATION.getFloat());
             json.put("trackViewCount", SettingsEnum.SB_COUNT_SKIPS.getBoolean());
             json.put("categorySelections", categorySelectionsArray);
-            json.put("userID", SettingsEnum.SB_UUID.getString());
-            json.put("isVip", SettingsEnum.SB_IS_VIP.getBoolean());
-            json.put("serverAddress", SettingsEnum.SB_API_URL.getString());
+            json.put("barTypes", barTypesObject);
 
             return json.toString();
         } catch (Exception ex) {

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
@@ -550,7 +550,9 @@ public abstract class SponsorBlockUtils {
 
             String serverAddress = settingsJson.getString("serverAddress");
             if (serverAddress.equalsIgnoreCase("https://sponsor.ajay.app")) {
-                serverAddress = (String) SettingsEnum.SB_API_URL.getDefaultValue(); // upgrade from old url
+                // the browser extension exports only the server address
+                // but this code expects the full url (https://sponsor.ajay.app/api/)
+                serverAddress = (String) SettingsEnum.SB_API_URL.getDefaultValue();
             }
             SettingsEnum.SB_API_URL.saveValue(serverAddress);
 

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
@@ -547,12 +547,10 @@ public abstract class SponsorBlockUtils {
             SettingsEnum.SB_IS_VIP.saveValue(settingsJson.getBoolean("isVip"));
             SettingsEnum.SB_MIN_DURATION.saveValue(Float.valueOf(settingsJson.getString("minDuration")));
             SettingsEnum.SB_UUID.saveValue(settingsJson.getString("userID"));
-            SettingsEnum.SB_LAST_VIP_CHECK.saveValue(settingsJson.getLong("lastIsVipUpdate"));
-
 
             String serverAddress = settingsJson.getString("serverAddress");
             if (serverAddress.equalsIgnoreCase("https://sponsor.ajay.app")) {
-                serverAddress = (String) SettingsEnum.SB_API_URL.getDefaultValue();
+                serverAddress = (String) SettingsEnum.SB_API_URL.getDefaultValue(); // upgrade from old url
             }
             SettingsEnum.SB_API_URL.saveValue(serverAddress);
 
@@ -593,7 +591,6 @@ public abstract class SponsorBlockUtils {
             json.put("categorySelections", categorySelectionsArray);
             json.put("userID", SettingsEnum.SB_UUID.getString());
             json.put("isVip", SettingsEnum.SB_IS_VIP.getBoolean());
-            json.put("lastIsVipUpdate", SettingsEnum.SB_LAST_VIP_CHECK.getLong());
             json.put("serverAddress", SettingsEnum.SB_API_URL.getString());
 
             return json.toString();

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
@@ -543,18 +543,11 @@ public abstract class SponsorBlockUtils {
 
             SettingsEnum.SB_UUID.saveValue(settingsJson.getString("userID"));
             SettingsEnum.SB_IS_VIP.saveValue(settingsJson.getBoolean("isVip"));
+            SettingsEnum.SB_API_URL.saveValue(settingsJson.getString("serverAddress"));
             SettingsEnum.SB_SHOW_TOAST_WHEN_SKIP.saveValue(!settingsJson.getBoolean("dontShowNotice"));
             SettingsEnum.SB_SHOW_TIME_WITHOUT_SEGMENTS.saveValue(settingsJson.getBoolean("showTimeWithSkips"));
             SettingsEnum.SB_MIN_DURATION.saveValue(Float.valueOf(settingsJson.getString("minDuration")));
             SettingsEnum.SB_COUNT_SKIPS.saveValue(settingsJson.getBoolean("trackViewCount"));
-
-            String serverAddress = settingsJson.getString("serverAddress");
-            if (serverAddress.equalsIgnoreCase("https://sponsor.ajay.app")) {
-                // the browser extension exports only the server address
-                // but this code expects the full url (https://sponsor.ajay.app/api/)
-                serverAddress = (String) SettingsEnum.SB_API_URL.getDefaultValue();
-            }
-            SettingsEnum.SB_API_URL.saveValue(serverAddress);
 
             Toast.makeText(context, str("settings_import_successful"), Toast.LENGTH_SHORT).show();
         } catch (Exception ex) {

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
@@ -46,6 +46,7 @@ import java.util.TimeZone;
 import app.revanced.integrations.settings.SettingsEnum;
 import app.revanced.integrations.sponsorblock.player.PlayerType;
 import app.revanced.integrations.utils.LogHelper;
+import app.revanced.integrations.utils.ReVancedUtils;
 import app.revanced.integrations.utils.SharedPrefHelper;
 import app.revanced.integrations.sponsorblock.objects.SponsorSegment;
 import app.revanced.integrations.sponsorblock.objects.UserStats;
@@ -154,7 +155,7 @@ public abstract class SponsorBlockUtils {
             Toast.makeText(context, str("submit_started"), Toast.LENGTH_SHORT).show();
 
             appContext = new WeakReference<>(context);
-            new Thread(submitRunnable).start();
+            ReVancedUtils.runOnBackgroundThread(submitRunnable);
         }
     };
     public static String messageToToast = "";

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/SponsorBlockUtils.java
@@ -470,6 +470,7 @@ public abstract class SponsorBlockUtils {
             category.addPreference(preference);
             String formatted = FORMATTER.format(stats.getSegmentCount());
             preference.setTitle(fromHtml(str("stats_submissions", formatted)));
+            preference.setSelectable(false);
         }
 
         {
@@ -503,6 +504,7 @@ public abstract class SponsorBlockUtils {
 
             preference.setTitle(fromHtml(str("stats_self_saved", formatted)));
             preference.setSummary(fromHtml(str("stats_self_saved_sum", formattedSaved)));
+            preference.setSelectable(false);
         }
     }
 

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
@@ -136,6 +136,7 @@ public class SBRequester {
                 String uuid = SettingsEnum.SB_UUID.getString();
                 String vote = Integer.toString(voteOption == VoteOption.UPVOTE ? 1 : 0);
 
+                // edit: could probably remove this toast, as another toast with the result is shown only a few seconds later
                 runOnMainThread(() -> Toast.makeText(context, str("vote_started"), Toast.LENGTH_SHORT).show());
 
                 HttpURLConnection connection = voteOption == VoteOption.CATEGORY_CHANGE
@@ -173,7 +174,9 @@ public class SBRequester {
                 JSONObject json = getJSONObject(SBRoutes.GET_USER_STATS, SettingsEnum.SB_UUID.getString());
                 UserStats stats = new UserStats(json.getString("userName"), json.getDouble("minutesSaved"), json.getInt("segmentCount"),
                         json.getInt("viewCount"));
-                SponsorBlockUtils.addUserStats(category, loadingPreference, stats);
+                runOnMainThread(() -> { // get back on main thread to modify UI elements
+                    SponsorBlockUtils.addUserStats(category, loadingPreference, stats);
+                });
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
@@ -31,6 +31,7 @@ import app.revanced.integrations.sponsorblock.SponsorBlockUtils;
 import app.revanced.integrations.sponsorblock.SponsorBlockUtils.VoteOption;
 import app.revanced.integrations.sponsorblock.objects.SponsorSegment;
 import app.revanced.integrations.sponsorblock.objects.UserStats;
+import app.revanced.integrations.utils.ReVancedUtils;
 
 public class SBRequester {
     private static final String TIME_TEMPLATE = "%.3f";
@@ -129,7 +130,7 @@ public class SBRequester {
     }
 
     public static void voteForSegment(SponsorSegment segment, VoteOption voteOption, Context context, String... args) {
-        new Thread(() -> {
+        ReVancedUtils.runOnBackgroundThread(() -> {
             try {
                 String segmentUuid = segment.UUID;
                 String uuid = SettingsEnum.SB_UUID.getString();
@@ -158,7 +159,7 @@ public class SBRequester {
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
-        }).start();
+        });
     }
 
     public static void retrieveUserStats(PreferenceCategory category, Preference loadingPreference) {
@@ -167,7 +168,7 @@ public class SBRequester {
             return;
         }
 
-        new Thread(() -> {
+        ReVancedUtils.runOnBackgroundThread(() -> {
             try {
                 JSONObject json = getJSONObject(SBRoutes.GET_USER_STATS, SettingsEnum.SB_UUID.getString());
                 UserStats stats = new UserStats(json.getString("userName"), json.getDouble("minutesSaved"), json.getInt("segmentCount"),
@@ -176,11 +177,11 @@ public class SBRequester {
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
-        }).start();
+        });
     }
 
     public static void setUsername(String username, EditTextPreference preference, Runnable toastRunnable) {
-        new Thread(() -> {
+        ReVancedUtils.runOnBackgroundThread(() -> {
             try {
                 HttpURLConnection connection = getConnectionFromRoute(SBRoutes.CHANGE_USERNAME, SettingsEnum.SB_UUID.getString(), username);
                 int responseCode = connection.getResponseCode();
@@ -199,7 +200,7 @@ public class SBRequester {
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
-        }).start();
+        });
     }
 
     public static void runVipCheck() {

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRequester.java
@@ -137,9 +137,6 @@ public class SBRequester {
                 String uuid = SettingsEnum.SB_UUID.getString();
                 String vote = Integer.toString(voteOption == VoteOption.UPVOTE ? 1 : 0);
 
-                // edit: could probably remove this toast, as another toast with the result is shown only a few seconds later
-                runOnMainThread(() -> Toast.makeText(context, str("vote_started"), Toast.LENGTH_SHORT).show());
-
                 HttpURLConnection connection = voteOption == VoteOption.CATEGORY_CHANGE
                         ? getConnectionFromRoute(SBRoutes.VOTE_ON_SEGMENT_CATEGORY, segmentUuid, uuid, args[0])
                         : getConnectionFromRoute(SBRoutes.VOTE_ON_SEGMENT_QUALITY, segmentUuid, uuid, vote);

--- a/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRoutes.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/requests/SBRoutes.java
@@ -5,15 +5,15 @@ import static app.revanced.integrations.requests.Route.Method.POST;
 
 import app.revanced.integrations.requests.Route;
 
-public class SBRoutes {
-    public static final Route IS_USER_VIP = new Route(GET, "isUserVIP?userID={user_id}");
-    public static final Route GET_SEGMENTS = new Route(GET, "skipSegments?videoID={video_id}&categories={categories}");
-    public static final Route VIEWED_SEGMENT = new Route(POST, "viewedVideoSponsorTime?UUID={segment_id}");
-    public static final Route GET_USER_STATS = new Route(GET, "userInfo?userID={user_id}&values=[\"userName\", \"minutesSaved\", \"segmentCount\", \"viewCount\"]");
-    public static final Route CHANGE_USERNAME = new Route(POST, "setUsername?userID={user_id}&username={username}");
-    public static final Route SUBMIT_SEGMENTS = new Route(POST, "skipSegments?videoID={video_id}&userID={user_id}&startTime={start_time}&endTime={end_time}&category={category}&videoDuration={duration}");
-    public static final Route VOTE_ON_SEGMENT_QUALITY = new Route(POST, "voteOnSponsorTime?UUID={segment_id}&userID={user_id}&type={type}");
-    public static final Route VOTE_ON_SEGMENT_CATEGORY = new Route(POST, "voteOnSponsorTime?UUID={segment_id}&userID={user_id}&category={category}");
+class SBRoutes {
+    static final Route IS_USER_VIP = new Route(GET, "/api/isUserVIP?userID={user_id}");
+    static final Route GET_SEGMENTS = new Route(GET, "/api/skipSegments?videoID={video_id}&categories={categories}");
+    static final Route VIEWED_SEGMENT = new Route(POST, "/api/viewedVideoSponsorTime?UUID={segment_id}");
+    static final Route GET_USER_STATS = new Route(GET, "/api/userInfo?userID={user_id}&values=[\"userName\", \"minutesSaved\", \"segmentCount\", \"viewCount\"]");
+    static final Route CHANGE_USERNAME = new Route(POST, "/api/setUsername?userID={user_id}&username={username}");
+    static final Route SUBMIT_SEGMENTS = new Route(POST, "/api/skipSegments?videoID={video_id}&userID={user_id}&startTime={start_time}&endTime={end_time}&category={category}&videoDuration={duration}");
+    static final Route VOTE_ON_SEGMENT_QUALITY = new Route(POST, "/api/voteOnSponsorTime?UUID={segment_id}&userID={user_id}&type={type}");
+    static final Route VOTE_ON_SEGMENT_CATEGORY = new Route(POST, "/api/voteOnSponsorTime?UUID={segment_id}&userID={user_id}&category={category}");
 
     private SBRoutes() {
     }

--- a/app/src/main/java/app/revanced/integrations/utils/ReVancedUtils.java
+++ b/app/src/main/java/app/revanced/integrations/utils/ReVancedUtils.java
@@ -38,7 +38,7 @@ public class ReVancedUtils {
      * All tasks run at max thread priority.
      */
     private static final ThreadPoolExecutor backgroundThreadPool = new ThreadPoolExecutor(
-            1, // minimum 1 thread always ready to be used
+            2, // minimum 2 threads always ready to be used
             10, // For any threads over the minimum, keep them alive 10 seconds after they go idle
             SHARED_THREAD_POOL_MAXIMUM_BACKGROUND_THREADS,
             TimeUnit.SECONDS,


### PR DESCRIPTION
- fixed importation of browser json settings (removed importation of non standard SB_LAST_VIP_CHECK)
- fixed user id always showing as empty string (prevented voting and user stats from working)
- fixed skip segment toast not working (settings activity was not passing some values into SettingEnum)

Everything appears to be working now.

Fixes revanced/revanced-patches/issues/1105, fixes revanced/revanced-patches/issues/1447.