### PR TITLE
fix(youtube/return-youtube-dislike): fix error toast when voting

### DIFF
--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -388,7 +388,7 @@ public class ReturnYouTubeDislike {
         ReVancedUtils.verifyOffMainThread();
 
         String userId = SettingsEnum.RYD_USER_ID.getString();
-        if (userId != null) {
+        if (!userId.isEmpty()) {
             return userId;
         }
 


### PR DESCRIPTION
Restored required change for recent SettingsEnum refactoring.

This change was originally made, but got lost in one of the merges.