### PR TITLE
fix(youtube/sponsorblock): settings do not show default behavior

### DIFF
--- a/app/src/main/java/app/revanced/integrations/sponsorblock/objects/SegmentCategoryListPreference.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/objects/SegmentCategoryListPreference.java
@@ -31,6 +31,7 @@ public class SegmentCategoryListPreference extends ListPreference {
         super(context);
         this.category = Objects.requireNonNull(category);
         setKey(category.key);
+        setDefaultValue(category.behaviour.key);
         setEntries(CategoryBehaviour.getBehaviorNames());
         setEntryValues(CategoryBehaviour.getBehaviorKeys());
         setSummary(category.description.toString());


### PR DESCRIPTION
fixed minor UI oversight, where the settings do not show the default behavior of each category.