### PR TITLE
fix(youtube/sponsorblock): change default behavior to better match the browser

### DIFF
--- a/app/src/main/java/app/revanced/integrations/sponsorblock/objects/SegmentCategory.java
+++ b/app/src/main/java/app/revanced/integrations/sponsorblock/objects/SegmentCategory.java
@@ -3,6 +3,7 @@ package app.revanced.integrations.sponsorblock.objects;
 import static app.revanced.integrations.sponsorblock.objects.CategoryBehaviour.IGNORE;
 import static app.revanced.integrations.sponsorblock.objects.CategoryBehaviour.MANUAL_SKIP;
 import static app.revanced.integrations.sponsorblock.objects.CategoryBehaviour.SKIP_AUTOMATICALLY;
+import static app.revanced.integrations.sponsorblock.objects.CategoryBehaviour.SKIP_AUTOMATICALLY_ONCE;
 import static app.revanced.integrations.utils.StringRef.sf;
 
 import android.content.SharedPreferences;
@@ -27,11 +28,11 @@ import app.revanced.integrations.utils.StringRef;
 
 public enum SegmentCategory {
     SPONSOR("sponsor", sf("sb_segments_sponsor"), sf("sb_segments_sponsor_sum"), sf("sb_skip_button_sponsor"), sf("sb_skipped_sponsor"),
-            SKIP_AUTOMATICALLY, 0x00D400),
+            SKIP_AUTOMATICALLY_ONCE, 0x00D400),
     SELF_PROMO("selfpromo", sf("sb_segments_selfpromo"), sf("sb_segments_selfpromo_sum"), sf("sb_skip_button_selfpromo"), sf("sb_skipped_selfpromo"),
-            SKIP_AUTOMATICALLY, 0xFFFF00),
+            MANUAL_SKIP, 0xFFFF00),
     INTERACTION("interaction", sf("sb_segments_interaction"), sf("sb_segments_interaction_sum"), sf("sb_skip_button_interaction"), sf("sb_skipped_interaction"),
-            SKIP_AUTOMATICALLY, 0xCC00FF),
+            MANUAL_SKIP, 0xCC00FF),
     INTRO("intro", sf("sb_segments_intro"), sf("sb_segments_intro_sum"),
             sf("sb_skip_button_intro_beginning"), sf("sb_skip_button_intro_middle"), sf("sb_skip_button_intro_end"),
             sf("sb_skipped_intro_beginning"), sf("sb_skipped_intro_middle"), sf("sb_skipped_intro_end"),


### PR DESCRIPTION
The SponsorBlock browser default behavior is:
- "Auto Skip" : Sponsor

**Although**, after installing the browser extension, the user is prompted with the categories and lets them change the behavior.  ReVanced does not do this, so adding additional default non intrusive behavior that "most people want" might be ok.


Currently ReVanced defaults to:
- "Auto Skip" : Sponsor, Self Promo, Interaction
- "Manual Skip" : Into, Outro, Music_Off_Topic

For ReVanced to match the browser as close as possible, ReVanced would use:
- "Auto Skip Once" : Sponsor

An intermediate between the current ReVanced defaults and an exact match of the browser, would be something like:
- "Auto Skip Once" : Sponsor
- "Manual Skip": Promo, Interaction, Intro, Outro, Music_Off_Topic

Note: the unique ReVanced "Skip Automatically Once" behavior more closely matches the browser "Auto Skip", as ReVanced does not have an undo skip function.


