### PR TITLE
fix(youtube/general-ads): remove broken ad filter

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/GeneralAdsPatch.java
@@ -64,7 +64,6 @@ public final class GeneralAdsPatch extends Filter {
                 "carousel_footered_layout",
                 "text_image_button_layout",
                 "primetime_promo",
-                "feature_grid_interstitial",
                 "product_details",
                 "brand_video_shelf"
         );


### PR DESCRIPTION
It removes the `buy premium` banner but semi-transparent overlay is still there.
![image](https://user-images.githubusercontent.com/107796137/231242222-54ba2f13-9d9a-41e8-bb1e-1255e95bf5d2.png)
