### PR TITLE
fix:(spoof-wifi-connection): fixed crash when wifi is disabled

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,6 +20,8 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -dontobfuscate
+-dontoptimize
+-keepattributes *  # https://www.guardsquare.com/manual/configuration/attributes
 -keep class app.revanced.** {
   *;
 }


### PR DESCRIPTION
Turned off proguard optimizations and added `-keepattributes` flag which keeps required attributes such as `InnerClasses`.

This will fix https://github.com/revanced/revanced-patches/issues/1935,
and should also fix https://github.com/revanced/revanced-patches/issues/1583


ProGuard will continue to remove unused code in the libraries used by ReVanced.