### PR TITLE
fix(youtube/return-youtube-dislike): fix potential error toast when using old UI layout

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
@@ -80,10 +80,11 @@ public class ReturnYouTubeDislikePatch {
      *
      * Used when spoofing the older app versions of {@link SpoofAppVersionPatch}.
      */
-    public static void setOldUILayoutDislikes(int buttonViewResourceId, @NonNull TextView textView) {
+    public static void setOldUILayoutDislikes(int buttonViewResourceId, @Nullable TextView textView) {
         try {
             if (!SettingsEnum.RYD_ENABLED.getBoolean()
-                    || buttonViewResourceId != OLD_UI_DISLIKE_BUTTON_RESOURCE_ID) {
+                    || buttonViewResourceId != OLD_UI_DISLIKE_BUTTON_RESOURCE_ID
+                    || textView == null) {
                 return;
             }
             if (oldUIOriginalSpan == null) {


### PR DESCRIPTION
Apparently the dislike text view can be null?  Not sure when this would happen, but check for it anyways.
