### PR TITLE
fix(youtube/spoof-app-version): restore watch history preview

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/HideBreakingNewsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/HideBreakingNewsPatch.java
@@ -6,9 +6,10 @@ import app.revanced.integrations.adremover.AdRemoverAPI;
 import app.revanced.integrations.settings.SettingsEnum;
 
 public class HideBreakingNewsPatch {
-    //Used by app.revanced.patches.youtube.layout.homepage.breakingnews.patch.BreakingNewsPatch
+
     public static void hideBreakingNews(View view) {
-        if (!SettingsEnum.HIDE_BREAKING_NEWS.getBoolean()) return;
+        // Don't hide if spoofing to an old version, as the component was previously used for the watch history.
+        if (!SettingsEnum.HIDE_BREAKING_NEWS.getBoolean() || SettingsEnum.SPOOF_APP_VERSION.getBoolean()) return;
         AdRemoverAPI.HideViewWithLayout1dp(view);
     }
 }


### PR DESCRIPTION
When spoofing to an old version, the`hide-breaking-news-shelf` patch incorrectly hides the watch history thumbnail previews.

As far as I know, the breaking news components are not present when spoofing to an old version of the app. So this should be a safe fix.