### PR TITLE
fix(youtube/remember-video-quality): do not show 'auto' in video resolution picker if a default quality is set

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/playback/quality/RememberVideoQualityPatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/playback/quality/RememberVideoQualityPatch.java
@@ -110,14 +110,24 @@ public class RememberVideoQualityPatch {
                 }
                 i++;
             }
+
+            // If the desired quality index is equal to the original index,
+            // then the video is already set to the desired default quality.
+            //
+            // The method could return here, but the UI video quality flyout will still
+            // show 'Auto' (ie: Auto (480p))
+            // It appears that "Auto" picks the resolution on video load,
+            // and it does not appear to change the resolution during playback.
+            //
+            // To prevent confusion, set the video index anyways (even if it matches the existing index)
+            // As that will force the UI picker to not display "Auto" which may confuse the user.
             if (qualityIndexToUse == originalQualityIndex) {
                 LogHelper.printDebug(() -> "Video is already preferred quality: " + preferredQuality);
-                return originalQualityIndex;
+            } else {
+                final int qualityToUseLog = qualityToUse;
+                LogHelper.printDebug(() -> "Quality changed from: "
+                        + videoQualities.get(originalQualityIndex) + " to: " + qualityToUseLog);
             }
-
-            final int qualityToUseLog = qualityToUse;
-            LogHelper.printDebug(() -> "Quality changed from: "
-                    + videoQualities.get(originalQualityIndex) + " to: " + qualityToUseLog);
 
             Method m = qInterface.getClass().getMethod(qIndexMethod, Integer.TYPE);
             m.invoke(qInterface, qualityToUse);


### PR DESCRIPTION
If the user has a default video quality that matches the video quality used by YouTube's "auto" quality selection,
then the player resolution picker will show "auto" even though it's the correct default resolution set in ReVanced.

'Auto' mode sets the video resolution on load, and it does not appear to change the resolution during video playback.  But users may be confused by this, since "Auto (480p)" appears to be different than "480p" (even though they are actually the same).


Changed the integration code, so it always sets the video quality (even if it's the same as the current).  As setting the resolution removes the "Auto" wording from the UI and resolves any user confusion.

Immediately after loading a video, with ReVanced default video quality set to 480p:
Before this PR:
![before pr](https://github.com/revanced/revanced-integrations/assets/118716522/0370a7a0-eae5-407a-85c0-9b5decc995d1)

This PR:
![after pr](https://github.com/revanced/revanced-integrations/assets/118716522/e23fd4e3-358d-4f91-a10b-7eccf0f42331)

