### PR TITLE
fix(youtube/ads-filter): remove duplicate filter

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/components/LayoutComponentsFilter.java
+++ b/app/src/main/java/app/revanced/integrations/patches/components/LayoutComponentsFilter.java
@@ -174,15 +174,7 @@ public final class LayoutComponentsFilter extends Filter {
                 channelMemberShelf
         );
 
-        final var carouselAd = new StringFilterGroup(
-                SettingsEnum.HIDE_GENERAL_ADS,
-                "carousel_ad"
-        );
-
-        this.identifierFilterGroups.addAll(
-                graySeparator,
-                carouselAd
-        );
+        this.identifierFilterGroups.addAll(graySeparator);
     }
 
     private boolean isMixPlaylistFiltered(final byte[] _protobufBufferArray) {


### PR DESCRIPTION
Also available in [AdsFilter](https://github.com/revanced/revanced-integrations/blob/170685b920de85133f33dfcc31bcc68eac3f6351/app/src/main/java/app/revanced/integrations/patches/components/AdsFilter.java#L58).