### PR TITLE
fix(youtube/return-youtube-dislike): fix dislikes not showing in some situations

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
@@ -202,7 +202,13 @@ public class ReturnYouTubeDislikePatch {
      */
     public static boolean setShortsDislikes(@NonNull View likeDislikeView) {
         try {
-            if (!SettingsEnum.RYD_ENABLED.getBoolean() || !SettingsEnum.RYD_SHORTS.getBoolean()) {
+            if (!SettingsEnum.RYD_ENABLED.getBoolean()) {
+                return false;
+            }
+            if (!SettingsEnum.RYD_SHORTS.getBoolean()) {
+                // Must clear the data here, in case a new video was loaded while PlayerType
+                // suggested the video was not a short (can happen when spoofing to an old app version).
+                ReturnYouTubeDislike.setCurrentVideoId(null);
                 return false;
             }
             LogHelper.printDebug(() -> "setShortsDislikes");
@@ -302,7 +308,7 @@ public class ReturnYouTubeDislikePatch {
             if (!videoId.equals(currentVideoId)) {
                 currentVideoId = videoId;
 
-                final boolean noneHiddenOrMinimized = PlayerType.getCurrent().isNoneHiddenOrMinimized();
+                final boolean noneHiddenOrMinimized = PlayerType.getCurrent().isNoneOrHidden();
                 if (noneHiddenOrMinimized && !SettingsEnum.RYD_SHORTS.getBoolean()) {
                     ReturnYouTubeDislike.setCurrentVideoId(null);
                     return;

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/ReturnYouTubeDislike.java
@@ -255,7 +255,7 @@ public class ReturnYouTubeDislike {
             // If a Short is opened while a regular video is on screen, this will incorrectly set this as false.
             // But this check is needed to fix unusual situations of opening/closing the app
             // while both a regular video and a short are on screen.
-            dislikeDataIsShort = currentPlayerType.isNoneHiddenOrMinimized();
+            dislikeDataIsShort = currentPlayerType.isNoneOrHidden();
 
             RYDCachedFetch entry = futureCache.get(videoId);
             if (entry != null && entry.futureInProgressOrFinishedSuccessfully()) {
@@ -371,7 +371,7 @@ public class ReturnYouTubeDislike {
             // Must make a local copy of videoId, since it may change between now and when the vote thread runs.
             String videoIdToVoteFor = getCurrentVideoId();
             if (videoIdToVoteFor == null ||
-                    (SettingsEnum.RYD_SHORTS.getBoolean() && dislikeDataIsShort != PlayerType.getCurrent().isNoneHiddenOrMinimized())) {
+                    (SettingsEnum.RYD_SHORTS.getBoolean() && dislikeDataIsShort != PlayerType.getCurrent().isNoneOrHidden())) {
                 // User enabled RYD after starting playback of a video.
                 // Or shorts was loaded with regular video present, then shorts was closed,
                 // and then user voted on the now visible original video.

--- a/app/src/main/java/app/revanced/integrations/shared/PlayerType.kt
+++ b/app/src/main/java/app/revanced/integrations/shared/PlayerType.kt
@@ -18,7 +18,7 @@ enum class PlayerType {
     HIDDEN,
     /**
      * When spoofing to 16.x YouTube and watching a short with a regular video in the background,
-     * the type will be this (and not [HIDDEN]).
+     * the type can be this (and not [HIDDEN]).
      */
     WATCH_WHILE_MINIMIZED,
     WATCH_WHILE_MAXIMIZED,


### PR DESCRIPTION
Fixes dislikes not showing if user has RYD for shorts turned off, and then user either:
- opens a new video while existing video is minimized 
- opens a video and then immediately minimizes before the video id hook runs