### PR TITLE
fix(YouTube - Hide Shorts components): Hide new type of shorts in feed

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/components/ShortsFilter.java
+++ b/app/src/main/java/app/revanced/integrations/patches/components/ShortsFilter.java
@@ -55,7 +55,8 @@ public final class ShortsFilter extends Filter {
                 "shorts_shelf",
                 "inline_shorts",
                 "shorts_grid",
-                "shorts_video_cell"
+                "shorts_video_cell",
+                "shorts_pivot_item"
         );
 
         pathFilterGroups.addAll(joinButton, subscribeButton, channelBar, soundButton, infoPanel);


### PR DESCRIPTION
![image](https://github.com/ReVanced/revanced-integrations/assets/107796137/e4010b4b-68e9-4eb5-bf88-e954d877e199)
