### PR TITLE
fix(YouTube - Player Flyout Menu): Change 'audio track flyout menu' to show up by default

### DIFF
--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -163,7 +163,7 @@ public enum SettingsEnum {
     HIDE_HELP_MENU("revanced_hide_player_flyout_help", BOOLEAN, TRUE),
     HIDE_SPEED_MENU("revanced_hide_player_flyout_speed", BOOLEAN, FALSE),
     HIDE_MORE_INFO_MENU("revanced_hide_player_flyout_more_info", BOOLEAN, TRUE),
-    HIDE_AUDIO_TRACK_MENU("revanced_hide_player_flyout_audio_track", BOOLEAN, TRUE),
+    HIDE_AUDIO_TRACK_MENU("revanced_hide_player_flyout_audio_track", BOOLEAN, FALSE),
     HIDE_WATCH_IN_VR_MENU("revanced_hide_player_flyout_watch_in_vr", BOOLEAN, TRUE),
 
     // Misc


### PR DESCRIPTION
The audio track button only appears on videos that have a secondary audio track (which are not many videos), and it's confusing why the option is missing if the user never decided to hide it.

Changed the default to show the flyout menu option, which is less confusing to users.