### PR TITLE
fix(YouTube/ExternalDownloads): Trim spaces from package

### DIFF
--- a/app/src/main/java/app/revanced/integrations/videoplayer/ExternalDownloadButton.java
+++ b/app/src/main/java/app/revanced/integrations/videoplayer/ExternalDownloadButton.java
@@ -49,7 +49,7 @@ public class ExternalDownloadButton extends BottomControlButton {
         LogHelper.printDebug(() -> "External download button clicked");
 
         final var context = view.getContext();
-        var downloaderPackageName = SettingsEnum.EXTERNAL_DOWNLOADER_PACKAGE_NAME.getString();
+        var downloaderPackageName = SettingsEnum.EXTERNAL_DOWNLOADER_PACKAGE_NAME.getString().trim();
 
         boolean packageEnabled = false;
         try {

--- a/app/src/main/java/app/revanced/integrations/videoplayer/ExternalDownloadButton.java
+++ b/app/src/main/java/app/revanced/integrations/videoplayer/ExternalDownloadButton.java
@@ -49,6 +49,7 @@ public class ExternalDownloadButton extends BottomControlButton {
         LogHelper.printDebug(() -> "External download button clicked");
 
         final var context = view.getContext();
+        // Trim string to avoid any accidental whitespace.
         var downloaderPackageName = SettingsEnum.EXTERNAL_DOWNLOADER_PACKAGE_NAME.getString().trim();
 
         boolean packageEnabled = false;


### PR DESCRIPTION
If there were spaces in the package name anywhere, revanced would show a toast saying that the package could not be found, ideally it should find it no matter if there are spaces in the package name or not. This fixes that.

As discussed in discord, ideally package names should be trimmed on settings save but there is currently no abstraction for settings (as far as i can reinterpret from that message).