### PR TITLE
fix(YouTube - Hide layout components): Always hide the redundant 'player audio track' button

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/components/LayoutComponentsFilter.java
+++ b/app/src/main/java/app/revanced/integrations/patches/components/LayoutComponentsFilter.java
@@ -92,8 +92,16 @@ public final class LayoutComponentsFilter extends Filter {
                 "channel_guidelines_entry_banner"
         );
 
+        // The player audio track button does the exact same function as the audio track flyout menu option.
+        // But if the copy url button is shown, these button clashes and the the audio button does not work.
+        // Previously this was a setting to show/hide the player button.
+        // But it was decided it's simpler to always hide this button because:
+        // - it doesn't work with copy video url feature
+        // - the button is rare
+        // - always hiding makes the ReVanced settings simpler and easier to understand
+        // - nobody is going to notice the redundant button is always hidden
         final var audioTrackButton = new StringFilterGroup(
-                SettingsEnum.HIDE_AUDIO_TRACK_BUTTON,
+                null,
                 "multi_feed_icon_button"
         );
 

--- a/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
+++ b/app/src/main/java/app/revanced/integrations/settings/SettingsEnum.java
@@ -97,7 +97,6 @@ public enum SettingsEnum {
     DISABLE_RESUMING_SHORTS_PLAYER("revanced_disable_resuming_shorts_player", BOOLEAN, FALSE),
     HIDE_ALBUM_CARDS("revanced_hide_album_cards", BOOLEAN, FALSE, true),
     HIDE_ARTIST_CARDS("revanced_hide_artist_cards", BOOLEAN, FALSE),
-    HIDE_AUDIO_TRACK_BUTTON("revanced_hide_audio_track_button", BOOLEAN, FALSE),
     HIDE_AUTOPLAY_BUTTON("revanced_hide_autoplay_button", BOOLEAN, TRUE, true),
     HIDE_BREAKING_NEWS("revanced_hide_breaking_news", BOOLEAN, TRUE, true),
     HIDE_CAPTIONS_BUTTON("revanced_hide_captions_button", BOOLEAN, FALSE),


### PR DESCRIPTION
integration changes for https://github.com/ReVanced/revanced-patches/pull/2951