### PR TITLE
fix(YouTube - ReturnYouTubeDislike): Do not retry API call if same fetch recently failed

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
@@ -25,6 +25,17 @@ import static app.revanced.integrations.returnyoutubedislike.ReturnYouTubeDislik
 
 /**
  * Handles all interaction of UI patch components.
+ *
+ * Known limitation:
+ * Litho based Shorts player can experience temporarily frozen video playback if the RYD fetch takes too long.
+ *
+ * Temporary work around:
+ * Enable app spoofing to version 18.20.39 or older, as that uses a non litho Shorts player.
+ *
+ * Permanent fix (yet to be implemented), either of:
+ * - Modify patch to hook onto the Shorts Litho TextView, and update the dislikes asynchronously.
+ * - Find a way to force Litho to rebuild it's component tree
+ *   (and use that hook to force the shorts dislikes to update after the fetch is completed).
  */
 public class ReturnYouTubeDislikePatch {
 
@@ -435,10 +446,10 @@ public class ReturnYouTubeDislikePatch {
                 lastLithoShortsVideoData = videoData;
                 lithoShortsShouldUseCurrentData = false;
             } else {
+                // All other playback (including non-litho Shorts).
                 if (videoIdIsSame(currentVideoData, videoId)) {
                     return;
                 }
-                // All other playback (including litho Shorts).
                 currentVideoData = ReturnYouTubeDislike.getFetchForVideoId(videoId);
             }
 

--- a/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -35,10 +35,10 @@ public class ReturnYouTubeDislikeApi {
     private static final int API_GET_VOTES_TCP_TIMEOUT_MILLISECONDS = 2000;
 
     /**
-     * {@link #fetchVotes(String)} HTTP read timeout
-     *  To locally debug and force timeouts, change this to a very small number (ie: 100)
+     * {@link #fetchVotes(String)} HTTP read timeout.
+     * To locally debug and force timeouts, change this to a very small number (ie: 100)
      */
-    private static final int API_GET_VOTES_HTTP_TIMEOUT_MILLISECONDS = 4000;
+    private static final int API_GET_VOTES_HTTP_TIMEOUT_MILLISECONDS = 5000;
 
     /**
      * Default connection and response timeout for voting and registration.


### PR DESCRIPTION
If a RYD fetch fails, then don't retry again until at least 1 minute has passed.

If swiping thru Shorts and RYD fails, this prevent showing multiple toasts for the same video.