### PR TITLE
fix(YouTube - Return YouTube Dislike): Wait until fetch is complete before allowing the first Short to start playback

### DIFF
--- a/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
+++ b/app/src/main/java/app/revanced/integrations/patches/ReturnYouTubeDislikePatch.java
@@ -579,8 +579,6 @@ public class ReturnYouTubeDislikePatch {
             }
             final boolean waitForFetchToComplete = !IS_SPOOFING_TO_NON_LITHO_SHORTS_PLAYER
                     && videoIdIsShort && !lastPlayerResponseWasShort;
-            lastPlayerResponseWasShort = videoIdIsShort;
-            lastPrefetchedVideoId = videoId;
 
             LogHelper.printDebug(() -> "Prefetching RYD for video: " + videoId);
             ReturnYouTubeDislike fetch = ReturnYouTubeDislike.getFetchForVideoId(videoId);
@@ -594,8 +592,11 @@ public class ReturnYouTubeDislikePatch {
                 //
                 // If an asynchronous litho Shorts solution is found, then this blocking call should be removed.
                 LogHelper.printDebug(() -> "Waiting for prefetch to complete: " + videoId);
-                fetch.getFetchData(10000); // Use any arbitrarily large max wait time.
+                fetch.getFetchData(20000); // Any arbitrarily large max wait time.
             }
+            // Set the fields after the fetch completes, so any concurrent calls will also wait.
+            lastPlayerResponseWasShort = videoIdIsShort;
+            lastPrefetchedVideoId = videoId;
         } catch (Exception ex) {
             LogHelper.printException(() -> "preloadVideoId failure", ex);
         }


### PR DESCRIPTION
Additional fix for https://github.com/ReVanced/revanced-integrations/pull/532

Two player responses can be parsed for the same video, and playback can start after either response is parsed.  That means all player responses for the first Short must wait until RYD finishes fetching (not just the fist response, as it was before this PR).
