### PR TITLE
fix(TikTok): Add missing settings strings

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/settings/Setting.java
+++ b/app/src/main/java/app/revanced/integrations/shared/settings/Setting.java
@@ -97,7 +97,7 @@ public abstract class Setting<T> {
     @NonNull
     private static List<Setting<?>> allLoadedSettingsSorted() {
         Collections.sort(SETTINGS, (Setting<?> o1, Setting<?> o2) -> o1.key.compareTo(o2.key));
-        return Collections.unmodifiableList(SETTINGS);
+        return allLoadedSettings();
     }
 
     /**
@@ -131,6 +131,7 @@ public abstract class Setting<T> {
 
     /**
      * Confirmation message to display, if the user tries to change the setting from the default value.
+     * Currently this works only for Boolean setting types.
      */
     @Nullable
     public final StringRef userDialogMessage;
@@ -206,10 +207,9 @@ public abstract class Setting<T> {
     /**
      * Migrate a setting value if the path is renamed but otherwise the old and new settings are identical.
      */
-    public static void migrateOldSettingToNew(@NonNull Setting<?> oldSetting, @NonNull Setting newSetting) {
+    public static <T> void migrateOldSettingToNew(@NonNull Setting<T> oldSetting, @NonNull Setting<T> newSetting) {
         if (!oldSetting.isSetToDefault()) {
             Logger.printInfo(() -> "Migrating old setting value: " + oldSetting + " into replacement setting: " + newSetting);
-            //noinspection unchecked
             newSetting.save(oldSetting.value);
             oldSetting.resetToDefault();
         }

--- a/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
@@ -7,6 +7,8 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.*;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import app.revanced.integrations.shared.Logger;
 import app.revanced.integrations.shared.Utils;
 import app.revanced.integrations.shared.settings.BooleanSetting;
@@ -24,6 +26,13 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
      * to apply the change from the Setting to the UI component.
      */
     public static boolean settingImportInProgress;
+
+    /**
+     * Confirm and restart dialog button text and title.
+     * Set by subclasses if Strings cannot be added as a resource.
+     */
+    @Nullable
+    protected static String restartDialogButtonText, restartDialogTitle, confirmDialogTitle;
 
     /**
      * Used to prevent showing reboot dialog, if user cancels a setting user dialog.
@@ -80,11 +89,15 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
     }
 
     private void showSettingUserDialogConfirmation(SwitchPreference switchPref, BooleanSetting setting) {
-        final var context = getContext();
+        Utils.verifyOnMainThread();
 
+        final var context = getContext();
+        if (confirmDialogTitle == null) {
+            confirmDialogTitle = str("revanced_settings_confirm_user_dialog_title");
+        }
         showingUserDialogMessage = true;
         new AlertDialog.Builder(context)
-                .setTitle(str("revanced_settings_confirm_user_dialog_title"))
+                .setTitle(confirmDialogTitle)
                 .setMessage(setting.userDialogMessage.toString())
                 .setPositiveButton(android.R.string.ok, (dialog, id) -> {
                     if (setting.rebootApp) {
@@ -201,12 +214,17 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
     }
 
     public static void showRestartDialog(@NonNull final Context context) {
-        String positiveButton = str("revanced_settings_restart");
-
-        new AlertDialog.Builder(context).setMessage(str("revanced_settings_restart_title"))
-                .setPositiveButton(positiveButton, (dialog, id) -> {
-                    Utils.restartApp(context);
-                })
+        Utils.verifyOnMainThread();
+        if (restartDialogTitle == null) {
+            restartDialogTitle = str("revanced_settings_restart_title");
+        }
+        if (restartDialogButtonText == null) {
+            restartDialogButtonText = str("revanced_settings_restart");
+        }
+        new AlertDialog.Builder(context)
+                .setMessage(restartDialogTitle)
+                .setPositiveButton(restartDialogButtonText, (dialog, id)
+                        -> Utils.restartApp(context))
                 .setNegativeButton(android.R.string.cancel, null)
                 .setCancelable(false)
                 .show();

--- a/app/src/main/java/app/revanced/integrations/tiktok/settings/preference/ReVancedPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/tiktok/settings/preference/ReVancedPreferenceFragment.java
@@ -17,6 +17,12 @@ public class ReVancedPreferenceFragment extends AbstractPreferenceFragment {
     protected void initialize() {
         final var context = getContext();
 
+        // Currently no resources can be compiled for TikTok (fails with aapt error).
+        // So all TikTok Strings are hard coded in integrations.
+        restartDialogTitle = "Refresh and restart";
+        restartDialogButtonText = "Restart";
+        confirmDialogTitle = "Do you wish to proceed?";
+
         PreferenceScreen preferenceScreen = getPreferenceManager().createPreferenceScreen(context);
         setPreferenceScreen(preferenceScreen);
 


### PR DESCRIPTION
Since strings cannot be added as resources to TikTok, the strings for the reset and confirm dialog are now fields so TikTok integrations can set them.

fixes https://github.com/ReVanced/revanced-patches/issues/2672