### PR TITLE
fix(YouTube - Litho Filter): Ignore null buffers

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/components/LithoFilterPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/components/LithoFilterPatch.java
@@ -509,6 +509,8 @@ public final class LithoFilterPatch {
         // The buffer will be cleared from memory after a new buffer is set by the same thread,
         // or when the calling thread eventually dies.
         if (protobufBuffer == null) {
+            // It appears the buffer can be cleared out just before the call to #filter()
+            // Ignore this null value and retain the last buffer that was set.
             Logger.printDebug(() -> "Ignoring null protobuffer");
         } else {
             bufferThreadLocal.set(protobufBuffer);


### PR DESCRIPTION
After looking at the patched code (which I should have done to begin with), it's now obvious the buffer can be null when calling into integrations.

So it's possible the buffer is getting cleared just before the call to `LithoFilter`. 
The safe solution is to ignore the null call and use whatever the buffer was last set to.

This may be the actual fix needed to completely resolve the action/flyout items inconsistently hiding in [revanced-patches#2694](https://www.github.com/ReVanced/revanced-patches/issues/2694)
