### PR TITLE
fix(YouTube - Spoof app version): Remove broken versions

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofAppVersionPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofAppVersionPatch.java
@@ -1,12 +1,26 @@
 package app.revanced.integrations.youtube.patches.spoof;
 
+import app.revanced.integrations.shared.Logger;
 import app.revanced.integrations.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public class SpoofAppVersionPatch {
 
-    private static final boolean SPOOF_APP_VERSION_ENABLED = Settings.SPOOF_APP_VERSION.get();
-    private static final String SPOOF_APP_VERSION_TARGET = Settings.SPOOF_APP_VERSION_TARGET.get();
+    private static final boolean SPOOF_APP_VERSION_ENABLED;
+    private static final String SPOOF_APP_VERSION_TARGET;
+
+    static {
+        // TODO: remove this migration code
+        // Spoof targets 16.x and 17.x that no longer reliably work.
+        if (Settings.SPOOF_APP_VERSION_TARGET.get().compareTo("18.01.01") < 0) {
+            Logger.printInfo(() -> "Resetting spoof app version target");
+            Settings.SPOOF_APP_VERSION_TARGET.resetToDefault();
+        }
+        // End migration
+
+        SPOOF_APP_VERSION_ENABLED = Settings.SPOOF_APP_VERSION.get();
+        SPOOF_APP_VERSION_TARGET = Settings.SPOOF_APP_VERSION_TARGET.get();
+    }
 
     /**
      * Injection point

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -129,7 +129,7 @@ public class Settings extends BaseSettings {
     public static final IntegerSetting PLAYER_OVERLAY_OPACITY = new IntegerSetting("revanced_player_overlay_opacity",100, true);
     public static final BooleanSetting PLAYER_POPUP_PANELS = new BooleanSetting("revanced_hide_player_popup_panels", FALSE);
     public static final BooleanSetting SPOOF_APP_VERSION = new BooleanSetting("revanced_spoof_app_version", FALSE, true, "revanced_spoof_app_version_user_dialog_message");
-    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("revanced_spoof_app_version_target", "17.08.35", true, parent(SPOOF_APP_VERSION));
+    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("revanced_spoof_app_version_target", "18.09.39", true, parent(SPOOF_APP_VERSION));
     public static final BooleanSetting SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON = new BooleanSetting("revanced_switch_create_with_notifications_button", TRUE, true);
     public static final BooleanSetting TABLET_LAYOUT = new BooleanSetting("revanced_tablet_layout", FALSE, true, "revanced_tablet_layout_user_dialog_message");
     public static final BooleanSetting USE_TABLET_MINIPLAYER = new BooleanSetting("revanced_tablet_miniplayer", FALSE, true);


### PR DESCRIPTION
Integrations for https://github.com/ReVanced/revanced-patches/pull/2776

- Changes default target to `18.09.39`
- Adds migration code for 16.x and 17.x targets
