### PR TITLE
feat(YouTube - Spoof app version): Add target versions

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofAppVersionPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofAppVersionPatch.java
@@ -11,8 +11,8 @@ public class SpoofAppVersionPatch {
 
     static {
         // TODO: remove this migration code
-        // Spoof targets 16.x and 17.x that no longer reliably work.
-        if (Settings.SPOOF_APP_VERSION_TARGET.get().compareTo("18.01.01") < 0) {
+        // Spoof targets below 17.33 that no longer reliably work.
+        if (Settings.SPOOF_APP_VERSION_TARGET.get().compareTo("17.33.01") < 0) {
             Logger.printInfo(() -> "Resetting spoof app version target");
             Settings.SPOOF_APP_VERSION_TARGET.resetToDefault();
         }

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -129,7 +129,7 @@ public class Settings extends BaseSettings {
     public static final IntegerSetting PLAYER_OVERLAY_OPACITY = new IntegerSetting("revanced_player_overlay_opacity",100, true);
     public static final BooleanSetting PLAYER_POPUP_PANELS = new BooleanSetting("revanced_hide_player_popup_panels", FALSE);
     public static final BooleanSetting SPOOF_APP_VERSION = new BooleanSetting("revanced_spoof_app_version", FALSE, true, "revanced_spoof_app_version_user_dialog_message");
-    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("revanced_spoof_app_version_target", "18.09.39", true, parent(SPOOF_APP_VERSION));
+    public static final StringSetting SPOOF_APP_VERSION_TARGET = new StringSetting("revanced_spoof_app_version_target", "17.33.42", true, parent(SPOOF_APP_VERSION));
     public static final BooleanSetting SWITCH_CREATE_WITH_NOTIFICATIONS_BUTTON = new BooleanSetting("revanced_switch_create_with_notifications_button", TRUE, true);
     public static final BooleanSetting TABLET_LAYOUT = new BooleanSetting("revanced_tablet_layout", FALSE, true, "revanced_tablet_layout_user_dialog_message");
     public static final BooleanSetting USE_TABLET_MINIPLAYER = new BooleanSetting("revanced_tablet_miniplayer", FALSE, true);


### PR DESCRIPTION
Integrations part of: https://github.com/ReVanced/revanced-patches/pull/2787

- Adjust the migration logic
- Change the default spoof target to 17.33.42