### PR TITLE
fix: Handle custom preferences

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
@@ -155,12 +155,12 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
      * Handles syncing a UI Preference with the {@link Setting} that backs it.
      * If needed, subclasses can override this to handle additional UI Preference types.
      *
-     * @param syncSetting If the UI should be synced {@link Setting} <-> Preference
      * @param applySettingToPreference If true, then apply {@link Setting} -> Preference.
      *                                 If false, then apply {@link Setting} <- Preference.
      */
-    protected void handlePreference(@NonNull Preference pref, @NonNull Setting<?> setting,
-                                    boolean syncSetting, boolean applySettingToPreference) {
+    protected void syncSettingWithPreference(@NonNull Preference pref,
+                                             @NonNull Setting<?> setting,
+                                             boolean applySettingToPreference) {
         if (pref instanceof SwitchPreference) {
             SwitchPreference switchPref = (SwitchPreference) pref;
             BooleanSetting boolSetting = (BooleanSetting) setting;
@@ -186,7 +186,6 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
             updateListPreferenceSummary(listPref, setting);
         } else {
             Logger.printException(() -> "Setting cannot be handled: " + pref.getClass() + ": " + pref);
-            return;
         }
     }
 
@@ -198,13 +197,13 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
      *                                 If false, then apply {@link Setting} <- Preference.
      */
     private void updatePreference(@NonNull Preference pref, @NonNull Setting<?> setting,
-                                    boolean syncSetting, boolean applySettingToPreference) {
+                                  boolean syncSetting, boolean applySettingToPreference) {
         if (!syncSetting && applySettingToPreference) {
             throw new IllegalArgumentException();
         }
 
         if (syncSetting) {
-            handlePreference(pref, setting, true, applySettingToPreference);
+            syncSettingWithPreference(pref, setting, applySettingToPreference);
         }
 
         updatePreferenceAvailability(pref, setting);

--- a/app/src/main/java/app/revanced/integrations/tiktok/settings/preference/ReVancedPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/tiktok/settings/preference/ReVancedPreferenceFragment.java
@@ -18,7 +18,9 @@ import org.jetbrains.annotations.NotNull;
 public class ReVancedPreferenceFragment extends AbstractPreferenceFragment {
 
     @Override
-    protected void handlePreference(@NonNull @NotNull Preference pref, @NonNull @NotNull Setting<?> setting, boolean syncSetting, boolean applySettingToPreference) {
+    protected void syncSettingWithPreference(@NonNull @NotNull Preference pref,
+                                             @NonNull @NotNull Setting<?> setting,
+                                             boolean applySettingToPreference) {
         if (pref instanceof RangeValuePreference) {
             RangeValuePreference rangeValuePref = (RangeValuePreference) pref;
             Setting.privateSetValueFromString(setting, rangeValuePref.getValue());
@@ -26,7 +28,7 @@ public class ReVancedPreferenceFragment extends AbstractPreferenceFragment {
             DownloadPathPreference downloadPathPref = (DownloadPathPreference) pref;
             Setting.privateSetValueFromString(setting, downloadPathPref.getValue());
         } else {
-            super.handlePreference(pref, setting, syncSetting, applySettingToPreference);
+            super.syncSettingWithPreference(pref, setting, applySettingToPreference);
         }
     }
 


### PR DESCRIPTION
Refactors the code so that subclasses can handle their preferences. Currently, open-closed principle is violated, and in the future, each preference should implement the preference handling itself. This can be done by passing down the corresponding setting it wraps and requiring it to implement the handling method so that it can be called.