### PR TITLE
chore: Remove unnecessary consumer parameter

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/announcements/AnnouncementsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/announcements/AnnouncementsPatch.java
@@ -18,7 +18,6 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Locale;
-import java.util.UUID;
 
 import static android.text.Html.FROM_HTML_MODE_COMPACT;
 import static app.revanced.integrations.shared.StringRef.str;
@@ -26,8 +25,6 @@ import static app.revanced.integrations.youtube.patches.announcements.requests.A
 
 @SuppressWarnings("unused")
 public final class AnnouncementsPatch {
-    private final static String CONSUMER = getOrSetConsumer();
-
     private AnnouncementsPatch() {
     }
 
@@ -41,7 +38,7 @@ public final class AnnouncementsPatch {
         Utils.runOnBackgroundThread(() -> {
             try {
                 HttpURLConnection connection = AnnouncementsRoutes.getAnnouncementsConnectionFromRoute(
-                        GET_LATEST_ANNOUNCEMENT, CONSUMER, Locale.getDefault().toLanguageTag());
+                        GET_LATEST_ANNOUNCEMENT, Locale.getDefault().toLanguageTag());
 
                 Logger.printDebug(() -> "Get latest announcement route connection url: " + connection.getURL());
 
@@ -137,15 +134,6 @@ public final class AnnouncementsPatch {
                 Logger.printException(() -> message, e);
             }
         });
-    }
-
-    private static String getOrSetConsumer() {
-        final var consumer = Settings.ANNOUNCEMENT_CONSUMER.get();
-        if (!consumer.isEmpty()) return consumer;
-
-        final var uuid = UUID.randomUUID().toString();
-        Settings.ANNOUNCEMENT_CONSUMER.save(uuid);
-        return uuid;
     }
 
     // TODO: Use better icons.

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/announcements/requests/AnnouncementsRoutes.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/announcements/requests/AnnouncementsRoutes.java
@@ -14,7 +14,7 @@ public class AnnouncementsRoutes {
     /**
      * 'language' parameter is IETF format (for USA it would be 'en-us').
      */
-    public static final Route GET_LATEST_ANNOUNCEMENT = new Route(GET, "/announcements/youtube/latest?consumer={consumer}&language={language}");
+    public static final Route GET_LATEST_ANNOUNCEMENT = new Route(GET, "/announcements/youtube/latest?language={language}");
 
     private AnnouncementsRoutes() {
     }

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -345,6 +345,10 @@ public class Settings extends BaseSettings {
         }
 
 
+        // Remove any previously saved announcement consumer (a random generated string).
+        Setting.preferences.saveString("revanced_announcement_consumer", null);
+
+
         // endregion
     }
 }

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -196,7 +196,6 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting SPOOF_DEVICE_DIMENSIONS = new BooleanSetting("revanced_spoof_device_dimensions", FALSE, true);
     public static final BooleanSetting BYPASS_URL_REDIRECTS = new BooleanSetting("revanced_bypass_url_redirects", TRUE);
     public static final BooleanSetting ANNOUNCEMENTS = new BooleanSetting("revanced_announcements", TRUE);
-    public static final StringSetting ANNOUNCEMENT_CONSUMER = new StringSetting("revanced_announcement_consumer", "", false, false);
    @Deprecated
     public static final StringSetting DEPRECATED_ANNOUNCEMENT_LAST_HASH = new StringSetting("revanced_announcement_last_hash", "");
     public static final IntegerSetting ANNOUNCEMENT_LAST_ID = new IntegerSetting("revanced_announcement_last_id", -1);


### PR DESCRIPTION
The query parameter was introduced with the intention of being used in the future. It turns out that it is not necessary and can be removed therefor.