### PR TITLE
fix(YouTube - Return YouTube Dislike): Do not show error toast if API success response contains new lines

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/returnyoutubedislike/requests/ReturnYouTubeDislikeApi.java
@@ -279,7 +279,7 @@ public class ReturnYouTubeDislikeApi {
             }
 
             if (responseCode == HTTP_STATUS_CODE_SUCCESS) {
-                // do not disconnect, the same server connection will likely be used again soon
+                // Do not disconnect, the same server connection will likely be used again soon.
                 JSONObject json = Requester.parseJSONObject(connection);
                 try {
                     RYDVoteData votingData = new RYDVoteData(json);
@@ -377,20 +377,17 @@ public class ReturnYouTubeDislikeApi {
                 connection.disconnect(); // disconnect, as no more connections will be made for a little while
                 return null;
             }
-            String result = null;
             if (responseCode == HTTP_STATUS_CODE_SUCCESS) {
-                result = Requester.parseJson(connection);
-                if (result.equalsIgnoreCase("true")) {
-                    Logger.printDebug(() -> "Registration confirmation successful");
-                    return userId;
-                }
+                Logger.printDebug(() -> "Registration confirmation successful");
+                return userId;
             }
-            final String resultLog = result == null ? "(no response)" : result;
+
+            // Something went wrong, might as well disconnect.
+            String response = Requester.parseJsonAndDisconnect(connection);
             Logger.printInfo(() -> "Failed to confirm registration for user: " + userId
-                    + " solution: " + solution + " responseCode: " + responseCode + " responseString: " + resultLog);
+                    + " solution: " + solution + " responseCode: " + responseCode + " response: '" + response + "''");
             handleConnectionError(str("revanced_ryd_failure_connection_status_code", responseCode),
                     null, true);
-            connection.disconnect(); // something went wrong, might as well disconnect
         } catch (SocketTimeoutException ex) {
             handleConnectionError(str("revanced_ryd_failure_connection_timeout"), ex, false);
         } catch (IOException ex) {
@@ -461,6 +458,7 @@ public class ReturnYouTubeDislikeApi {
                 String solution = solvePuzzle(challenge, difficulty);
                 return confirmVote(videoId, userId, solution);
             }
+
             Logger.printInfo(() -> "Failed to send vote for video: " + videoId + " vote: " + vote
                     + " response code was: " + responseCode);
             handleConnectionError(str("revanced_ryd_failure_connection_status_code", responseCode),
@@ -501,20 +499,17 @@ public class ReturnYouTubeDislikeApi {
                 connection.disconnect(); // disconnect, as no more connections will be made for a little while
                 return false;
             }
-            String result = null;
             if (responseCode == HTTP_STATUS_CODE_SUCCESS) {
-                result = Requester.parseJson(connection);
-                if (result.equalsIgnoreCase("true")) {
-                    Logger.printDebug(() -> "Vote confirm successful for video: " + videoId);
-                    return true;
-                }
+                Logger.printDebug(() -> "Vote confirm successful for video: " + videoId);
+                return true;
             }
-            final String resultLog = result == null ? "(no response)" : result;
+
+            // Something went wrong, might as well disconnect.
+            String response = Requester.parseJsonAndDisconnect(connection);
             Logger.printInfo(() -> "Failed to confirm vote for video: " + videoId
-                    + " solution: " + solution + " responseCode: " + responseCode + " responseString: " + resultLog);
+                    + " solution: " + solution + " responseCode: " + responseCode + " response: '" + response + "'");
             handleConnectionError(str("revanced_ryd_failure_connection_status_code", responseCode),
                     null, true);
-            connection.disconnect(); // something went wrong, might as well disconnect
         } catch (SocketTimeoutException ex) {
             handleConnectionError(str("revanced_ryd_failure_connection_timeout"), ex, false);
         } catch (IOException ex) {


### PR DESCRIPTION
RYD is now returning a newline at the end of its 200 status response of "true".

This is cause errors because integrations did not anticipate receiving a response of "true\n".

This fixes it by checking only the status response code.


Should probably merge dev to main soon, as without this fix an error shows up every time a user thumbs up or down.