### PR TITLE
fix(YouTube - Client spoof): Spoof iOS client model to fix various side effects

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/Utils.java
+++ b/app/src/main/java/app/revanced/integrations/shared/Utils.java
@@ -59,7 +59,7 @@ public class Utils {
     }
 
     /**
-     * @return The version name of the app, such as "YouTube".
+     * @return The version name of the app, such as 19.11.43
      */
     public static String getAppVersionName() {
         if (versionName == null) {

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -4,6 +4,7 @@ import static app.revanced.integrations.youtube.patches.spoof.requests.Storyboar
 
 import android.net.Uri;
 
+import android.os.Build;
 import androidx.annotation.Nullable;
 
 import java.util.Collections;
@@ -150,6 +151,17 @@ public class SpoofClientPatch {
     /**
      * Injection point.
      */
+    public static String getClientModel(String originalClientModel) {
+        if (SPOOF_CLIENT_ENABLED) {
+            return getSpoofClientType().model;
+        }
+
+        return originalClientModel;
+    }
+
+    /**
+     * Injection point.
+     */
     public static boolean isClientSpoofingEnabled() {
         return SPOOF_CLIENT_ENABLED;
     }
@@ -250,14 +262,16 @@ public class SpoofClientPatch {
     }
 
     private enum ClientType {
-        ANDROID_TESTSUITE(30, "1.9"),
-        IOS(5, Utils.getAppVersionName());
+        ANDROID_TESTSUITE(30, Build.MODEL, "1.9"),
+        IOS(5, "iPhone15,4", Utils.getAppVersionName());
 
         final int id;
+        final String model;
         final String version;
 
-        ClientType(int id, String version) {
+        ClientType(int id, String model, String version) {
             this.id = id;
+            this.model = model;
             this.version = version;
         }
     }

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -263,7 +263,7 @@ public class SpoofClientPatch {
 
     private enum ClientType {
         ANDROID_TESTSUITE(30, Build.MODEL, "1.9"),
-        IOS(5, "iPhone15,4", Utils.getAppVersionName());
+        IOS(5, "iPhone16,2", Utils.getAppVersionName()); // iPhone 15 Pro Max
 
         final int id;
         final String model;

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -23,8 +23,8 @@ import app.revanced.integrations.youtube.settings.Settings;
 @SuppressWarnings("unused")
 public class SpoofClientPatch {
     private static final boolean SPOOF_CLIENT_ENABLED = Settings.SPOOF_CLIENT.get();
-    private static final boolean SPOOF_CLIENT_USE_IOS = Settings.SPOOF_CLIENT_USE_IOS.get();
-    private static final boolean SPOOF_CLIENT_STORYBOARD = SPOOF_CLIENT_ENABLED && !SPOOF_CLIENT_USE_IOS;
+    private static final boolean SPOOF_CLIENT_USE_TEST_SUITE = Settings.SPOOF_CLIENT_USE_TESTSUITE.get();
+    private static final boolean SPOOF_CLIENT_STORYBOARD = SPOOF_CLIENT_ENABLED && SPOOF_CLIENT_USE_TEST_SUITE;
 
     /**
      * Any unreachable ip address.  Used to intentionally fail requests.
@@ -47,10 +47,10 @@ public class SpoofClientPatch {
 
     /**
      * Injection point.
-     * Blocks /get_watch requests by returning a localhost URI.
+     * Blocks /get_watch requests by returning an unreachable URI.
      *
      * @param playerRequestUri The URI of the player request.
-     * @return Localhost URI if the request is a /get_watch request, otherwise the original URI.
+     * @return An unreachable URI if the request is a /get_watch request, otherwise the original URI.
      */
     public static Uri blockGetWatchRequest(Uri playerRequestUri) {
         if (SPOOF_CLIENT_ENABLED) {
@@ -103,7 +103,7 @@ public class SpoofClientPatch {
     }
 
     private static ClientType getSpoofClientType() {
-        if (SPOOF_CLIENT_USE_IOS) {
+        if (!SPOOF_CLIENT_USE_TEST_SUITE) {
             return ClientType.IOS;
         }
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -263,7 +263,10 @@ public class SpoofClientPatch {
 
     private enum ClientType {
         ANDROID_TESTSUITE(30, Build.MODEL, "1.9"),
-        IOS(5, "iPhone16,2", Utils.getAppVersionName()); // iPhone 15 Pro Max
+        // 16,2 = iPhone 15 Pro Max.
+        // Version number should be a valid iOS release.
+        // https://www.ipa4fun.com/history/185230
+        IOS(5, "iPhone16,2", "19.10.7");
 
         final int id;
         final String model;

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -237,7 +237,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting BYPASS_URL_REDIRECTS = new BooleanSetting("revanced_bypass_url_redirects", TRUE);
     public static final BooleanSetting ANNOUNCEMENTS = new BooleanSetting("revanced_announcements", TRUE);
     public static final BooleanSetting SPOOF_CLIENT = new BooleanSetting("revanced_spoof_client", TRUE, true, "revanced_spoof_client_user_dialog_message");
-    public static final BooleanSetting SPOOF_CLIENT_USE_IOS = new BooleanSetting("revanced_spoof_client_use_ios", TRUE, true, parent(SPOOF_CLIENT));
+    public static final BooleanSetting SPOOF_CLIENT_USE_TESTSUITE = new BooleanSetting("revanced_spoof_client_use_testsuite", FALSE, true, parent(SPOOF_CLIENT));
     @Deprecated
     public static final StringSetting DEPRECATED_ANNOUNCEMENT_LAST_HASH = new StringSetting("revanced_announcement_last_hash", "");
     public static final IntegerSetting ANNOUNCEMENT_LAST_ID = new IntegerSetting("revanced_announcement_last_id", -1);

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/Settings.java
@@ -237,7 +237,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting BYPASS_URL_REDIRECTS = new BooleanSetting("revanced_bypass_url_redirects", TRUE);
     public static final BooleanSetting ANNOUNCEMENTS = new BooleanSetting("revanced_announcements", TRUE);
     public static final BooleanSetting SPOOF_CLIENT = new BooleanSetting("revanced_spoof_client", TRUE, true, "revanced_spoof_client_user_dialog_message");
-    public static final BooleanSetting SPOOF_CLIENT_USE_IOS = new BooleanSetting("revanced_spoof_client_use_ios", FALSE, true, parent(SPOOF_CLIENT));
+    public static final BooleanSetting SPOOF_CLIENT_USE_IOS = new BooleanSetting("revanced_spoof_client_use_ios", TRUE, true, parent(SPOOF_CLIENT));
     @Deprecated
     public static final StringSetting DEPRECATED_ANNOUNCEMENT_LAST_HASH = new StringSetting("revanced_announcement_last_hash", "");
     public static final IntegerSetting ANNOUNCEMENT_LAST_ID = new IntegerSetting("revanced_announcement_last_id", -1);


### PR DESCRIPTION
This PR also changes the default client spoof to iOS, as the only side effect known now is that HDR is not working.