### PR TITLE
 fix(YouTube/Spoof client): player gestures not working when spoofing with `Android VR` client

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -104,6 +104,13 @@ public class SpoofClientPatch {
     /**
      * Injection point.
      */
+    public static boolean enablePlayerGesture(boolean original) {
+        return SPOOF_CLIENT_ENABLED || original;
+    }
+
+    /**
+     * Injection point.
+     */
     public static boolean isClientSpoofingEnabled() {
         return SPOOF_CLIENT_ENABLED;
     }


### PR DESCRIPTION
Courtesy: https://github.com/inotia00/revanced-integrations/commit/41d50ae5626beb5d10c4a21753fd8caf151a768b