### PR TITLE
fix(YouTube - SponsorBlock): Skip segments when casting

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
@@ -208,16 +208,15 @@ public final class VideoInformation {
 
             // Try calling the seekTo method of the MDX player director (called when casting) if the player controller one failed.
             // The difference has to be a different second mark in order to avoid infinite skip loops (as the Lounge API only supports seconds).
-            if (Math.abs(adjustedSeekTime/1000 - videoTime/1000) >= 1) {
-                try {
-                    //noinspection DataFlowIssue
-                    return (Boolean) mdxSeekMethod.invoke(mdxPlayerDirectorRef.get(), adjustedSeekTime);
-                } catch (Exception ex) {
-                    Logger.printInfo(() -> "seekTo (MDX) method call failed", ex);
-                    return false;
-                }
-            } else {
-                Logger.printDebug(() -> "Skipping seekTo for MDX because of a small relative value (" + (seekTime - videoTime) + "ms).");
+            if ((adjustedSeekTime / 1000) == (videoTime / 1000)) {
+                Logger.printDebug(() -> String.format("Skipping seekTo for MDX because of a small relative value (%d ms).", adjustedSeekTime - videoTime));
+                return false;
+            }
+            try {
+                //noinspection DataFlowIssue
+                return (Boolean) mdxSeekMethod.invoke(mdxPlayerDirectorRef.get(), adjustedSeekTime);
+            } catch (Exception ex) {
+                Logger.printInfo(() -> "seekTo (MDX) method call failed", ex);
                 return false;
             }
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
@@ -201,15 +201,17 @@ public final class VideoInformation {
                 //noinspection DataFlowIssue
                 if ((Boolean) seekMethod.invoke(playerControllerRef.get(), adjustedSeekTime)) {
                     return true;
-                }
+                } // Else the video is loading or changing videos, or video is casting to a different device.
             } catch (Exception ex) {
                 Logger.printInfo(() -> "seekTo method call failed", ex);
             }
 
-            // Try calling the seekTo method of the MDX player director (called when casting) if the player controller one failed.
-            // The difference has to be a different second mark in order to avoid infinite skip loops (as the Lounge API only supports seconds).
+            // Try calling the seekTo method of the MDX player director (called when casting).
+            // The difference has to be a different second mark in order to avoid infinite skip loops
+            // as the Lounge API only supports seconds.
             if ((adjustedSeekTime / 1000) == (videoTime / 1000)) {
-                Logger.printDebug(() -> String.format("Skipping seekTo for MDX because of a small relative value (%d ms).", adjustedSeekTime - videoTime));
+                Logger.printDebug(() -> "Skipping seekTo for MDX because seek time is too small ("
+                        + (adjustedSeekTime - videoTime) + "ms)");
                 return false;
             }
             try {

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
@@ -72,7 +72,6 @@ public final class VideoInformation {
 
             mdxSeekMethod = mdxPlayerDirector.getClass().getMethod(SEEK_METHOD_NAME, Long.TYPE);
             mdxSeekMethod.setAccessible(true);
-
         } catch (Exception ex) {
             Logger.printException(() -> "Failed to initialize MDX", ex);
         }

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/VideoInformation.java
@@ -208,8 +208,8 @@ public final class VideoInformation {
             }
 
             // Try calling the seekTo method of the MDX player director (called when casting) if the player controller one failed.
-            // The difference has to be at least 1000ms to avoid infinite skip loops (the seekTo Lounge API command only supports seconds).
-            if (Math.abs(adjustedSeekTime - videoTime) >= 1000) {
+            // The difference has to be a different second mark in order to avoid infinite skip loops (as the Lounge API only supports seconds).
+            if (Math.abs(adjustedSeekTime/1000 - videoTime/1000) >= 1) {
                 try {
                     //noinspection DataFlowIssue
                     return (Boolean) mdxSeekMethod.invoke(mdxPlayerDirectorRef.get(), adjustedSeekTime);


### PR DESCRIPTION
Add integration code to support skipping segments while casted to a big screen device, by hooking the MDX director class to intercept object instances in order to be able to call the seekTo method, similar to how it's done in the 'regular' player class.

Fixes https://github.com/ReVanced/revanced-patches/issues/374.

Patches PR: https://github.com/ReVanced/revanced-patches/pull/3331