### PR TITLE
fix(YouTube - Spoof client): Restore livestream audio only playback with iOS spoofing

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/Utils.java
+++ b/app/src/main/java/app/revanced/integrations/shared/Utils.java
@@ -273,7 +273,6 @@ public class Utils {
                                                   @NonNull MatchFilter<View> filter) {
         for (int i = 0, childCount = viewGroup.getChildCount(); i < childCount; i++) {
             View childAt = viewGroup.getChildAt(i);
-            Logger.printDebug(() -> "View id: " + childAt.getId() + " tag: " + childAt.getTag());
 
             if (filter.matches(childAt)) {
                 //noinspection unchecked
@@ -285,6 +284,7 @@ public class Utils {
                 if (match != null) return match;
             }
         }
+
         return null;
     }
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -5,6 +5,7 @@ import android.media.MediaCodecList;
 import android.net.Uri;
 import android.os.Build;
 import app.revanced.integrations.shared.Logger;
+import app.revanced.integrations.youtube.patches.BackgroundPlaybackPatch;
 import app.revanced.integrations.youtube.settings.Settings;
 import org.chromium.net.ExperimentalUrlRequest;
 
@@ -134,7 +135,7 @@ public class SpoofClientPatch {
      * Return true to force audio only background play.
      */
     public static boolean enableLivestreamAudioOnlyPlayback() {
-        return SPOOFING_TO_IOS;
+        return SPOOFING_TO_IOS && BackgroundPlaybackPatch.playbackIsNotShort();
     }
 
     /**

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -22,13 +22,6 @@ public class SpoofClientPatch {
     private static final Uri UNREACHABLE_HOST_URI = Uri.parse(UNREACHABLE_HOST_URI_STRING);
 
     /**
-     * Tracking URL authority to use when spoofing the client to iOS,
-     * because watch history is not working on brand accounts.
-     * See <a href="https://github.com/LuanRT/YouTube.js/blob/3153375bcaa6c03afba9da8474e6a9d37471ed29/src/core/mixins/MediaInfo.ts#L152">LuanRT/YouTube.js</a>.
-     */
-    private static final String WWW_TRACKING_URL_AUTHORITY = "www.youtube.com";
-
-    /**
      * Injection point.
      * Blocks /get_watch requests by returning an unreachable URI.
      *
@@ -132,9 +125,9 @@ public class SpoofClientPatch {
     /**
      * Injection point.
      * When spoofing the client to iOS, background audio only playback of livestreams fails.
-     * Return true to force audio only background play.
+     * Return true to force enable audio background play.
      */
-    public static boolean enableLivestreamAudioOnlyPlayback() {
+    public static boolean overrideBackgroundAudioPlayback() {
         return SPOOFING_TO_IOS && BackgroundPlaybackPatch.playbackIsNotShort();
     }
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -128,6 +128,14 @@ public class SpoofClientPatch {
         return SPOOFING_TO_IOS || original;
     }
 
+    /**
+     * Injection point.
+     * When spoofing the client to iOS, background audio only playback of livestreams fails.
+     * Return true to force audio only background play.
+     */
+    public static boolean enableLivestreamAudioOnlyPlayback() {
+        return SPOOFING_TO_IOS;
+    }
 
     /**
      * Injection point.

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofClientPatch.java
@@ -153,19 +153,6 @@ public class SpoofClientPatch {
         return builder.build();
     }
 
-    /**
-     * Injection point.
-     * When spoofing the client to iOS, history is not working on brand accounts.
-     * Replace the tracking URL authority to {@link SpoofClientPatch#WWW_TRACKING_URL_AUTHORITY} to fix this.
-     */
-    public static Uri overrideTrackingUrl(Uri trackingUrl) {
-        if (SPOOF_CLIENT_ENABLED && SPOOF_CLIENT_TYPE == ClientType.IOS) {
-            return trackingUrl.buildUpon().authority(WWW_TRACKING_URL_AUTHORITY).build();
-        }
-
-        return trackingUrl;
-    }
-
     private enum ClientType {
         // https://dumps.tadiphone.dev/dumps/oculus/eureka
         ANDROID_VR(28,


### PR DESCRIPTION
Integration changes for https://github.com/ReVanced/revanced-patches/pull/3504