### PR TITLE
fix(YouTube - Return YouTube Dislike): Fix dislikes not appearing due to new component name

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/ReturnYouTubeDislikePatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/ReturnYouTubeDislikePatch.java
@@ -221,12 +221,12 @@ public class ReturnYouTubeDislikePatch {
 
             String conversionContextString = conversionContext.toString();
 
-            if (isRollingNumber && !conversionContextString.contains("video_action_bar.eml|")) {
+            if (isRollingNumber && !conversionContextString.contains("video_action_bar.eml")) {
                 return original;
             }
 
             final CharSequence replacement;
-            if (conversionContextString.contains("|segmented_like_dislike_button.eml|")) {
+            if (conversionContextString.contains("segmented_like_dislike_button.eml")) {
                 // Regular video.
                 ReturnYouTubeDislike videoData = currentVideoData;
                 if (videoData == null) {


### PR DESCRIPTION
Some users report this A/B test:

![image](https://github.com/user-attachments/assets/8c80419d-3cfb-470f-8e5b-0cbc18ec250b)

The change does not affect users without the A/B test