### PR TITLE
fix(YouTube - Hide layout components): Hide search result shelf header

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/components/LayoutComponentsFilter.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/components/LayoutComponentsFilter.java
@@ -198,7 +198,7 @@ public final class LayoutComponentsFilter extends Filter {
 
         searchResultShelfHeader = new StringFilterGroup(
                 Settings.HIDE_SEARCH_RESULT_SHELF_HEADER,
-                "shelf_header.eml"
+                "compact_channel.eml"
         );
 
         notifyMe = new StringFilterGroup(


### PR DESCRIPTION
Closes [#8](https://github.com/ReVanced/revanced-patches/issues/8)