### PR TITLE
fix(YouTube - GmsCore support): Show an error toast if GmsCore is included with root mounted installation

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/GmsCoreSupport.java
+++ b/app/src/main/java/app/revanced/integrations/shared/GmsCoreSupport.java
@@ -81,7 +81,7 @@ public class GmsCoreSupport {
                 Logger.printInfo(() -> "App is mounted with root, but GmsCore patch was included");
                 // Cannot use localize text here, since the app will load
                 // resources from the unpatched app and all patch strings are missing.
-                Utils.showToastLong("'GmsCore support' patch cannot be used with root mount installation");
+                Utils.showToastLong("The 'GmsCore support' patch breaks mount installations");
 
                 // Do not exit. If the app exits before launch completes (and without
                 // opening another activity), then on some devices such as Pixel phone Android 10


### PR DESCRIPTION
Adds a more informative toast that is shown if the user patched with default patches (which includes `GmsCore support`) and then installs the app with mount installation.

Without this PR, the user will only get an error message that `gms_core_toast_not_installed_message` is not found, because the app is trying to load strings from the original unpatched app (which obviously has no patch strings).


