### PR TITLE
fix(YouTube - Check watch history domain name resolution): Do not show warning if network connection is flaky

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/Utils.java
+++ b/app/src/main/java/app/revanced/integrations/shared/Utils.java
@@ -386,10 +386,10 @@ public class Utils {
     }
 
     /**
-     * Ignore this class. It must be public to satisfy Android requirement.
+     * Ignore this class. It must be public to satisfy Android requirements.
      */
     @SuppressWarnings("deprecation")
-    public static class DialogFragmentWrapper extends DialogFragment {
+    public static final class DialogFragmentWrapper extends DialogFragment {
 
         private Dialog dialog;
         @Nullable


### PR DESCRIPTION
Fixes false positive if the network is down but the `Utils.isNetworkConnected()` check has not detected the connection failure yet.