### PR TITLE
fix(YouTube - Spoof video streams): Handle app left open for a long time

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofVideoStreamsPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/spoof/SpoofVideoStreamsPatch.java
@@ -69,15 +69,9 @@ public class SpoofVideoStreamsPatch {
                 String path = originalUri.getPath();
 
                 if (path != null && path.contains("initplayback")) {
-                    // This previously returned an unreachable URL and it seemed to work for nearly all situations,
-                    // but an unreachable url would cause playback failure if the app changes to/from mobile
-                    // or if the app is left open for a long period of time.
-                    //
-                    // Presumably the failure is caused by a side effect that does not occur right away,
-                    // but this is only speculation and the exact reason why this fix works is is not clear.
-                    Logger.printDebug(() -> "Blocking 'initplayback' by clearing query");
+                    Logger.printDebug(() -> "Blocking 'initplayback' by returning unreachable url");
 
-                    return originalUri.buildUpon().clearQuery().build().toString();
+                    return UNREACHABLE_HOST_URI_STRING;
                 }
             } catch (Exception ex) {
                 Logger.printException(() -> "blockInitPlaybackRequest failure", ex);


### PR DESCRIPTION
Seems to fix random playback errors when the app is left open for a long period of time.