### PR TITLE
fix(YouTube - Hide layout components): Hide new kind of community post

### DIFF
--- a/app/src/main/java/app/revanced/integrations/youtube/patches/components/LayoutComponentsFilter.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/components/LayoutComponentsFilter.java
@@ -83,6 +83,7 @@ public final class LayoutComponentsFilter extends Filter {
                 "text_post_root.eml",
                 "images_post_root.eml",
                 "images_post_slim.eml",
+                "images_post_root_slim.eml",
                 "text_post_root_slim.eml",
                 "post_base_wrapper_slim.eml"
         );


### PR DESCRIPTION
Tested version: 19.39.37

<details>
<summary>Details</summary>

![Screenshot_2024-10-05-12-47-53-167_app revanced android youtube-edit](https://github.com/user-attachments/assets/69a2af07-ab81-4448-84c0-d37e2345f076)
![Screenshot_2024-10-05-13-06-03-161_com termux-edit](https://github.com/user-attachments/assets/233a8d56-b74e-4dd7-ba52-3b547af75f09)

</details>