### PR TITLE
fix(YouTube - Settings): Use multiline preference title for localized languages

### DIFF
--- a/app/src/main/java/app/revanced/integrations/shared/Utils.java
+++ b/app/src/main/java/app/revanced/integrations/shared/Utils.java
@@ -13,7 +13,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.preference.Preference;
-import android.preference.PreferenceCategory;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.view.View;
@@ -746,8 +745,8 @@ public class Utils {
             Preference pref = group.getPreference(i);
             pref.setSingleLineTitle(false);
 
-            if (pref instanceof PreferenceCategory) {
-                setPreferenceTitlesToMultiLineIfNeeded((PreferenceCategory) pref);
+            if (pref instanceof PreferenceGroup) {
+                setPreferenceTitlesToMultiLineIfNeeded((PreferenceGroup) pref);
             }
         }
     }

--- a/app/src/main/java/app/revanced/integrations/shared/Utils.java
+++ b/app/src/main/java/app/revanced/integrations/shared/Utils.java
@@ -13,6 +13,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.preference.Preference;
+import android.preference.PreferenceCategory;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.view.View;
@@ -719,6 +720,35 @@ public class Utils {
             }
 
             pref.setOrder(order);
+        }
+    }
+
+    /**
+     * Set all preferences to multiline titles if the device is not using an English variant.
+     * The English strings are heavily scrutinized and all titles fit on screen
+     * except 2 or 3 preference strings and those do not affect readability.
+     *
+     * Allowing multiline for those 2 or 3 English preferences looks weird and out of place,
+     * and visually it looks better to clip the text and keep all titles 1 line.
+     */
+    @SuppressWarnings("deprecation")
+    public static void setPreferenceTitlesToMultiLineIfNeeded(PreferenceGroup group) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        String deviceLanguage = Utils.getContext().getResources().getConfiguration().locale.getLanguage();
+        if (deviceLanguage.equals("en")) {
+            return;
+        }
+
+        for (int i = 0, prefCount = group.getPreferenceCount(); i < prefCount; i++) {
+            Preference pref = group.getPreference(i);
+            pref.setSingleLineTitle(false);
+
+            if (pref instanceof PreferenceCategory) {
+                setPreferenceTitlesToMultiLineIfNeeded((PreferenceCategory) pref);
+            }
         }
     }
 

--- a/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
@@ -80,10 +80,12 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
      */
     protected void initialize() {
         final var identifier = Utils.getResourceIdentifier("revanced_prefs", "xml");
-
         if (identifier == 0) return;
         addPreferencesFromResource(identifier);
-        Utils.sortPreferenceGroups(getPreferenceScreen());
+
+        PreferenceScreen screen = getPreferenceScreen();
+        Utils.sortPreferenceGroups(screen);
+        Utils.setPreferenceTitlesToMultiLineIfNeeded(screen);
     }
 
     private void showSettingUserDialogConfirmation(SwitchPreference switchPref, BooleanSetting setting) {

--- a/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/shared/settings/preference/AbstractPreferenceFragment.java
@@ -17,7 +17,7 @@ import app.revanced.integrations.shared.settings.Setting;
 
 import static app.revanced.integrations.shared.StringRef.str;
 
-@SuppressWarnings({"unused", "deprecation"})
+@SuppressWarnings("deprecation")
 public abstract class AbstractPreferenceFragment extends PreferenceFragment {
     /**
      * Indicates that if a preference changes,

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/MiniplayerPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/MiniplayerPatch.java
@@ -196,8 +196,6 @@ public final class MiniplayerPatch {
      * Injection point.
      */
     public static boolean getModernFeatureFlagsActiveOverride(boolean original) {
-        if (original) Logger.printDebug(() -> "getModernFeatureFlagsActiveOverride original: " + original);
-
         if (CURRENT_TYPE == ORIGINAL) {
             return original;
         }
@@ -209,8 +207,6 @@ public final class MiniplayerPatch {
      * Injection point.
      */
     public static boolean enableMiniplayerDoubleTapAction(boolean original) {
-        if (original) Logger.printDebug(() -> "enableMiniplayerDoubleTapAction original: " + true);
-
         if (CURRENT_TYPE == ORIGINAL) {
             return original;
         }
@@ -222,8 +218,6 @@ public final class MiniplayerPatch {
      * Injection point.
      */
     public static boolean enableMiniplayerDragAndDrop(boolean original) {
-        if (original) Logger.printDebug(() -> "enableMiniplayerDragAndDrop original: " + true);
-
         if (CURRENT_TYPE == ORIGINAL) {
             return original;
         }
@@ -236,8 +230,6 @@ public final class MiniplayerPatch {
      * Injection point.
      */
     public static boolean setRoundedCorners(boolean original) {
-        if (original) Logger.printDebug(() -> "setRoundedCorners original: " + true);
-
         if (CURRENT_TYPE.isModern()) {
             return MINIPLAYER_ROUNDED_CORNERS_ENABLED;
         }
@@ -271,8 +263,6 @@ public final class MiniplayerPatch {
      * Injection point.
      */
     public static boolean setDropShadow(boolean original) {
-        if (original) Logger.printDebug(() -> "setViewElevation original: " + true);
-
         return original;
     }
 

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/components/LithoFilterPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/components/LithoFilterPatch.java
@@ -155,7 +155,6 @@ public final class LithoFilterPatch {
             // Potentially the buffer may have been null or never set up until now.
             // Use an empty buffer so the litho id/path filters still work correctly.
             if (protobufBuffer == null) {
-                Logger.printDebug(() -> "Proto buffer is null, using an empty buffer array");
                 bufferArray = EMPTY_BYTE_ARRAY;
             } else if (!protobufBuffer.hasArray()) {
                 Logger.printDebug(() -> "Proto buffer does not have an array, using an empty buffer array");

--- a/app/src/main/java/app/revanced/integrations/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/patches/playback/speed/CustomPlaybackSpeedPatch.java
@@ -89,6 +89,7 @@ public class CustomPlaybackSpeedPatch {
     /**
      * Initialize a settings preference list with the available playback speeds.
      */
+    @SuppressWarnings("deprecation")
     public static void initializeListPreference(ListPreference preference) {
         if (preferenceListEntries == null) {
             preferenceListEntries = new String[customPlaybackSpeeds.length];

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/preference/ReVancedPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/preference/ReVancedPreferenceFragment.java
@@ -1,10 +1,7 @@
 package app.revanced.integrations.youtube.settings.preference;
 
-import android.os.Build;
 import android.preference.ListPreference;
 import android.preference.Preference;
-
-import androidx.annotation.RequiresApi;
 
 import app.revanced.integrations.shared.Logger;
 import app.revanced.integrations.shared.settings.preference.AbstractPreferenceFragment;
@@ -18,7 +15,6 @@ import app.revanced.integrations.youtube.settings.Settings;
  */
 public class ReVancedPreferenceFragment extends AbstractPreferenceFragment {
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     protected void initialize() {
         super.initialize();

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/preference/ReturnYouTubeDislikePreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/preference/ReturnYouTubeDislikePreferenceFragment.java
@@ -14,6 +14,7 @@ import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 
 import app.revanced.integrations.shared.Logger;
+import app.revanced.integrations.shared.Utils;
 import app.revanced.integrations.shared.settings.Setting;
 import app.revanced.integrations.shared.settings.BaseSettings;
 import app.revanced.integrations.youtube.patches.ReturnYouTubeDislikePatch;
@@ -218,6 +219,8 @@ public class ReturnYouTubeDislikePreferenceFragment extends PreferenceFragment {
                         "revanced_ryd_statistics_getNumberOfRateLimitRequestsEncountered_non_zero_summary"));
                 preferenceScreen.addPreference(statisticPreference);
             }
+
+            Utils.setPreferenceTitlesToMultiLineIfNeeded(preferenceScreen);
         } catch (Exception ex) {
             Logger.printException(() -> "onCreate failure", ex);
         }

--- a/app/src/main/java/app/revanced/integrations/youtube/settings/preference/SponsorBlockPreferenceFragment.java
+++ b/app/src/main/java/app/revanced/integrations/youtube/settings/preference/SponsorBlockPreferenceFragment.java
@@ -155,6 +155,8 @@ public class SponsorBlockPreferenceFragment extends PreferenceFragment {
             addAboutCategory(context, preferenceScreen);
 
             updateUI();
+
+            Utils.setPreferenceTitlesToMultiLineIfNeeded(preferenceScreen);
         } catch (Exception ex) {
             Logger.printException(() -> "onCreate failure", ex);
         }
@@ -468,6 +470,8 @@ public class SponsorBlockPreferenceFragment extends PreferenceFragment {
                     Utils.runOnMainThread(() -> { // get back on main thread to modify UI elements
                         addUserStats(loadingPlaceholderPreference, stats);
                         addLocalUserStats();
+
+                        Utils.setPreferenceTitlesToMultiLineIfNeeded(statsCategory);
                     });
                 });
             } else {


### PR DESCRIPTION
Fixes preference titles clipping when using localized langauges.

Many of the localized preference titles do not fit into 1 line and many are unreadable.

This PR sets the titles to multiline if the device is using a localized language.

The English strings do not require multiline, and the 2 or 3 English preferences that overrun are only partially clipped and still readable.  Making those couple of preferences multiline looks weird and out of place, and visually it is better to clip the text and keep all titles 1 line.

<details>
<summary>Before (Single line)</summary>

![Screenshot_20241024_083249_YouTube](https://github.com/user-attachments/assets/c3bf533e-74fb-4bea-b93d-8778c8b3bd63)

</details>

<details>
<summary>After (Multiline)</summary>

![Screenshot_20241024_080418_YouTube](https://github.com/user-attachments/assets/0f150ff2-a683-4628-ac03-ae168c9edba5)

</details>

